### PR TITLE
fix: In gnoclient Render and QEval, need to check Response.Error

### DIFF
--- a/gnoclient/client_queries.go
+++ b/gnoclient/client_queries.go
@@ -93,6 +93,9 @@ func (c Client) Render(pkgPath string, args string) (string, *ctypes.ResultABCIQ
 	if err != nil {
 		return "", nil, errors.Wrap(err, "query render")
 	}
+	if qres.Response.Error != nil {
+		return "", nil, errors.Wrap(qres.Response.Error, "Render failed: log:%s", qres.Response.Log)
+	}
 
 	return string(qres.Response.Data), qres, nil
 }
@@ -112,6 +115,9 @@ func (c Client) QEval(pkgPath string, expression string) (string, *ctypes.Result
 	qres, err := c.RPCClient.ABCIQuery(path, data)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "query qeval")
+	}
+	if qres.Response.Error != nil {
+		return "", nil, errors.Wrap(qres.Response.Error, "QEval failed: log:%s", qres.Response.Log)
 	}
 
 	return string(qres.Response.Data), qres, nil


### PR DESCRIPTION
In a call to ABCIQuery, if the error from the node is not in the `err` value but in the node response in `qres.Response.Error`. This includes errors like "invalid package path". The gnoclient method `Query` already [checks for this](https://github.com/gnolang/gnomobile/blob/c3100eef69ee3c608c108bedc7eeff0ba4bde4ab/gnoclient/client_queries.go#L31-L33). We need to do a similar check in the new methods `Render` and `QEval`.