### PR TITLE
chore: In the README, rename gnomobile to Gno Native Kit or gnonative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gnomobile
+# Gno Native Kit
 
 Current Gno apps run on desktop/laptop computers which have Go installed. To run on mobile, the app would need to bundle the Go runtime which is complicated for most developers. However our devs have years of experience with using Go on mobile and overcoming other difficulties of the Android and iOS operating systems. 
 
-Therefore, we demonstrate that it is possible to run a Gno app on mobile. This project's objective is to create a proof-of-concept mobile application which stores a Gno wallet on the mobile and calls a realm function on a remote Gno.land node and to create this software framework called GnoMobile. The ultimate objective of GnoMobile is to allow other Gno developers to easily offer their apps to run on mobile devices.
+Therefore, we demonstrate that it is possible to run a Gno app on mobile. This project's objective is to create a proof-of-concept mobile application which stores a Gno wallet on the mobile and calls a realm function on a remote Gno.land node and to create this software framework called Gno Native Kit. The ultimate objective of Gno Native Kit is to allow other Gno developers to easily offer their apps to run on mobile devices.
 
 ## Build instructions
 
@@ -62,8 +62,8 @@ To launch Android Studio, in a terminal enter:
 ### Get a copy of the repo
 
 ```console
-git clone https://github.com/gnolang/gnomobile
-cd gnomobile
+git clone https://github.com/gnolang/gnonative
+cd gnonative
 ```
 
 ### Build for Android


### PR DESCRIPTION
We renamed the project from GnoMobile to Gno Native Kit, and renamed the repo from gnolang/gnomobile to gnolang/gnonative . This is a quick update to the README to use the new name. We can update the internal go package names and the README project description in a later PR.