### PR TITLE
chore: Update gnoNativeService Call to the new gnoclient API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	connectrpc.com/connect v1.13.0
 	connectrpc.com/grpchealth v1.2.0
 	connectrpc.com/grpcreflect v1.2.0
-	github.com/gnolang/gno v0.0.0-20240126161128-7382d7c04154
+	github.com/gnolang/gno v0.0.0-20240202111440-37c1c31b0531
 	github.com/oklog/run v1.1.0
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/peterbourgon/unixtransport v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gno v0.0.0-20240126161128-7382d7c04154 h1:3SifsjEBImgzHMc1JpfGTvdb9qR9+NyhjbHqKHcw2Ng=
-github.com/gnolang/gno v0.0.0-20240126161128-7382d7c04154/go.mod h1:pzlpRF80RfVsWpstEumplkhDnAhzkbgSpoVOio3jkJs=
+github.com/gnolang/gno v0.0.0-20240202111440-37c1c31b0531 h1:4jFxLmDtGl3RrNtyFKOLeLVmFaFAdfFDXtKC4GdxzwI=
+github.com/gnolang/gno v0.0.0-20240202111440-37c1c31b0531/go.mod h1:pzlpRF80RfVsWpstEumplkhDnAhzkbgSpoVOio3jkJs=
 github.com/gnolang/goleveldb v0.0.9 h1:Q7rGko9oXMKtQA+Apeeed5a3sjba/mcDhzJGoTVLCKE=
 github.com/gnolang/goleveldb v0.0.9/go.mod h1:Dz6p9bmpy/FBESTgduiThZt5mToVDipcHGzj/zUOo8E=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=

--- a/service/api.go
+++ b/service/api.go
@@ -346,17 +346,18 @@ func (s *gnoNativeService) Call(ctx context.Context, req *connect.Request[api_ge
 	}
 	s.lock.RUnlock()
 
-	cfg := gnoclient.CallCfg{
-		PkgPath:   req.Msg.PackagePath,
-		FuncName:  req.Msg.Fnc,
-		Args:      req.Msg.Args,
+	cfg := gnoclient.BaseTxCfg{
 		GasFee:    req.Msg.GasFee,
 		GasWanted: req.Msg.GasWanted,
-		Send:      req.Msg.Send,
 		Memo:      req.Msg.Memo,
 	}
 
-	bres, err := s.client.Call(cfg)
+	bres, err := s.client.Call(cfg, gnoclient.MsgCall{
+		PkgPath:  req.Msg.PackagePath,
+		FuncName: req.Msg.Fnc,
+		Args:     req.Msg.Args,
+		Send:     req.Msg.Send,
+	})
 	if err != nil {
 		return getGrpcError(err)
 	}


### PR DESCRIPTION
A [recent PR](https://github.com/gnolang/gno/pull/1565) updates the [gnoclient `Call` method](https://github.com/gnolang/gno/pull/1565/files#diff-752f791213b77833b3df087a07a123d4a03f522436c96b03e5e57aa2461e18f8). So we need to update gnonative to use it.
This PR updates go.mod to use the latest gnolang/gno, and updates gnoNativeService `Call` to use the new format.