### PR TITLE
fix: In use-gno-web call, need to use MsgCall like in use-gno

### DIFF
--- a/templates/es/use-gno-web.ts
+++ b/templates/es/use-gno-web.ts
@@ -347,13 +347,15 @@ export const useGno = (): GnoResponse => {
     const client = await getClient();
     const reponse = client.call(
       new CallRequest({
-        packagePath,
-        fnc,
-        args,
         gasFee,
         gasWanted: BigInt(gasWanted),
-        send,
         memo,
+        msgs: [new MsgCall({
+          packagePath,
+          fnc,
+          args,
+          send,
+        })],
       }),
     );
     return reponse;


### PR DESCRIPTION
PR #114 updated `call` to use `MsgCall`. This included all the "use-gno" files, but I missed one. This PR updates `call` in use-gno-web to use `MsgCall`, like [in use-gno](https://github.com/gnolang/gnonative/pull/114/files#diff-7abed41c7fed8c0f475e3e64482f4037fba5233053f90278a09cc4a6f78610bb). 