### PR TITLE
fix: In QueryAccount, allow nil PubKey

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -272,10 +272,14 @@ func (s *gnoNativeService) QueryAccount(ctx context.Context, req *connect.Reques
 		})
 	}
 
+	var pubKeyBytes []byte
+	if account.PubKey != nil {
+		pubKeyBytes = account.PubKey.Bytes()
+	}
 	res := connect.NewResponse(&api_gen.QueryAccountResponse{AccountInfo: &api_gen.BaseAccount{
 		Address:       account.Address.Bytes(),
 		Coins:         formattedCoins,
-		PubKey:        account.PubKey.Bytes(),
+		PubKey:        pubKeyBytes,
 		AccountNumber: account.AccountNumber,
 		Sequence:      account.Sequence,
 	}})


### PR DESCRIPTION
When calling `QueryAccount` on a blockchain, the response `PubKey` can be nil if there is only a coin transaction for the account address. The problem is that the conversion code in api.go expects a non-nil value. For example, in the gnoboard app with the Portal Loop remote node, `QueryAccount` for the test1 account address throws the error "Thread 11: EXC_BAD_ACCESS (code=1, address=0x20)" for the [code here](https://github.com/gnolang/gnonative/blob/8d48ee0f612be5b465eda993214fcfdfa89563d5/service/api.go#L278).

This PR, checks if the response `PubKey` is nil. 