### PR TITLE
chore: Rename chain ID tendermint_test to dev

### DIFF
--- a/examples/js/react-native/gnoboard/src/resources/chains/chains.json
+++ b/examples/js/react-native/gnoboard/src/resources/chains/chains.json
@@ -10,7 +10,7 @@
     "gnoAddress": "test3.gno.land:36657"
   },
   {
-    "chainId": "tendermint_test",
+    "chainId": "dev",
     "chainName": "Berty-Dev",
     "gnoAddress": "testnet.gno.berty.io:36657"
   },


### PR DESCRIPTION
A [recent commit](https://github.com/gnolang/gno/blame/01e91be7bbde8e9cfc2069f66f24bc83d677103a/contribs/gnodev/main.go#L54) updates gnodev to use the chain ID "dev". When gnodev is updated locally or on the Berty test node, it needs to use this chain ID. So, this PR renames "tendermint_test" to "dev".