### PR TITLE
chore: Install jq with brew (not asdf)

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,4 +5,3 @@ java openjdk-18.0.1.1
 yarn 1.22.19
 golang 1.21.7
 buf 1.15.1
-jq 1.6

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To install asdf using brew, follow instructions at https://asdf-vm.com . In shor
 first install brew following the instructions at https://brew.sh . Then, in
 a terminal enter:
 
-    brew install asdf gnu-tar gpg
+    brew install asdf gnu-tar gpg jq
 
 If your terminal is zsh, enter:
 


### PR DESCRIPTION
It seems that asdf doesn't support jq on some platforms. (We've had trouble with macOS M1, both laptops and virtual machines.) This PR removes jq from .tool-versions and updates the README to install it with brew.