### PR TITLE
fix: release CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,58 @@ name: Semantic Release
 on:
   push:
     branches:
-      - master
+      - main
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: "Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)"
+        required: false
+        default: false
 jobs:
   semantic-release:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        with:
+          detached: true
+          limit-access-to-actor: true
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+
       - name: Setup asdf
-        uses: asdf-vm/actions/install@v3
+        uses: asdf-vm/actions/setup@v3
+
+      - name: Setup Go version
+        run: |
+          asdf plugin add golang
+          asdf install golang
+          echo "go_version=$(asdf current golang | xargs | cut -d ' ' -f 2)" >> $GITHUB_ENV
+
+      - name: Setup Node version
+        run: |
+          asdf plugin add nodejs
+          asdf install nodejs
+          asdf global nodejs 18.16.0
+          echo "node_version=$(asdf current nodejs | xargs | cut -d ' ' -f 2)" >> $GITHUB_ENV
+
+      - name: Cache go modules
+        uses: actions/cache@v4
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ env.go_version }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-go-${{ env.go_version }}-
+
+      - name: Cache node_modules
+        id: node_modules-cache
+        uses: actions/cache@v4
+        with:
+          path: ./expo/node_modules
+          key: ${{ runner.OS }}-node-${{ env.node_version }}-${{ hashFiles('expo/package-lock.json') }}
+          restore-keys: ${{ runner.OS }}-node-${{ env.node_version }}-
 
       - name: Compile frameworks
         working-directory: expo

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,3 @@
+{
+  "branches": ["main"]
+}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,3 +1,0 @@
-module.exports = {
-  branch: "main",
-};

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ PATH := $(GO_BIND_BIN_DIR):$(PATH)
 all build: generate build.ios build.android
 
 # Build iOS framework
-build.ios: generate $(gnocore_xcframework)
+build.ios: generate framework.ios
 ifeq ($(OS),Darwin)
 	@echo "generate iOS framework"
 	cd $(APP_OUTPUT_DIR); $(MAKE) node_modules
@@ -53,7 +53,7 @@ ifeq ($(OS),Darwin)
 endif
 
 # Build Android aar & jar
-build.android: generate $(gnocore_aar) $(gnocore_jar)
+build.android: generate framework.android
 	cd $(APP_OUTPUT_DIR); $(MAKE) node_modules
 
 # Generate API from protofiles
@@ -133,6 +133,9 @@ $(TEMPDIR)/.tool-versions: .tool-versions
 
 # - Bind - ios framework
 
+framework.ios: $(gnocore_xcframework)
+.PHONY: framework.ios
+
 $(gnocore_xcframework): $(bind_init_files) $(go_deps)
 ifeq ($(OS),Darwin)
 	@mkdir -p $(dir $@)
@@ -146,6 +149,9 @@ _bind.clean.ios:
 	rm -rf $(gnocore_xcframework)
 
 # - Bind - android aar and jar
+
+framework.android: $(gnocore_aar) $(gnocore_jar)
+.PHONY: framework.android
 
 $(gnocore_aar): $(bind_init_files) $(go_deps)
 	@mkdir -p $(dir $@) .cache/bind/android

--- a/expo/Makefile
+++ b/expo/Makefile
@@ -24,7 +24,7 @@ build.android: $(ANDROID_FRAMEWORK_DST)
 .PHONY: build.android
 
 $(ANDROID_FRAMEWORK_SRC):
-	cd $(PROJECT_DIR); $(MAKE) build.android
+	cd $(PROJECT_DIR); $(MAKE) framework.android
 
 $(ANDROID_FRAMEWORK_DST): $(ANDROID_FRAMEWORK_SRC)
 	mkdir -p $(ANDROID_FRAMEWORK_OUTPUT_DIR)
@@ -40,7 +40,7 @@ build.ios: $(IOS_FRAMEWORK_DST)
 .PHONY: build.ios
 
 $(IOS_FRAMEWORK_SRC):
-	cd $(PROJECT_DIR); $(MAKE) build.ios
+	cd $(PROJECT_DIR); $(MAKE) framework.ios
 
 $(IOS_FRAMEWORK_DST): $(IOS_FRAMEWORK_SRC)
 	mkdir -p $(IOS_FRAMEWORK_OUTPUT_DIR)

--- a/expo/Makefile
+++ b/expo/Makefile
@@ -49,3 +49,14 @@ $(IOS_FRAMEWORK_DST): $(IOS_FRAMEWORK_SRC)
 clean.ios:
 	rm -fr $(IOS_FRAMEWORK_OUTPUT_DIR)
 .PHONY: clean.ios
+
+######### NPM #########
+npm.pack: build
+	npm install
+	npm pack
+.PHONY: npm.pack
+
+npm.publish: build
+	npm install
+	npm publish
+.PHONY: npm.publish

--- a/expo/README.md
+++ b/expo/README.md
@@ -102,3 +102,17 @@ npx expo run:ios
 For bare React Native projects, you must ensure that you have
 [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/)
 before continuing.
+
+# Generate new NPM package
+
+You can run one of the following command:
+
+```shell
+npm pack
+```
+
+or
+
+```shell
+npm publish
+```

--- a/expo/README.md
+++ b/expo/README.md
@@ -33,7 +33,7 @@ cd my-app
 ## Add the package to your npm dependencies
 
 ```
-npm install @berty/gnonative
+npm install @gnolang/gnonative
 ```
 
 ## Customize the app
@@ -46,7 +46,7 @@ Open App.js and replace the content with this:
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
-import * as Gnonative from '@berty/gnonative';
+import * as Gnonative from '@gnolang/gnonative';
 
 export default function App() {
   const gno = Gnonative.useGno();

--- a/expo/README.md
+++ b/expo/README.md
@@ -108,11 +108,11 @@ before continuing.
 You can run one of the following command:
 
 ```shell
-npm pack
+make pack
 ```
 
 or
 
 ```shell
-npm publish
+make publish
 ```

--- a/expo/example/App.tsx
+++ b/expo/example/App.tsx
@@ -1,4 +1,4 @@
-import * as Gnonative from '@berty/gnonative';
+import * as Gnonative from '@gnolang/gnonative';
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 

--- a/expo/example/metro.config.js
+++ b/expo/example/metro.config.js
@@ -19,7 +19,7 @@ config.resolver.nodeModulesPaths = [
 ];
 
 config.resolver.extraNodeModules = {
-  '@berty/gnonative': '..',
+  '@gnolang/gnonative': '..',
 };
 
 config.watchFolders = [path.resolve(__dirname, '..')];

--- a/expo/example/tsconfig.json
+++ b/expo/example/tsconfig.json
@@ -3,10 +3,10 @@
   "compilerOptions": {
     "strict": true,
     "paths": {
-      "@berty/gnonative": [
+      "@gnolang/gnonative": [
         "../src/index"
       ],
-      "@berty/gnonative/*": [
+      "@gnolang/gnonative/*": [
         "../src/*"
       ]
     }

--- a/expo/example/webpack.config.js
+++ b/expo/example/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = async (env, argv) => {
     {
       ...env,
       babel: {
-        dangerouslyAddModulePathsToTranspile: ['@bertygnonative'],
+        dangerouslyAddModulePathsToTranspile: ['@gnolang/gnonative'],
       },
     },
     argv,

--- a/expo/package-lock.json
+++ b/expo/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@berty/gnonative",
-  "version": "0.1.0",
+  "name": "@gnolang/gnonative",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@berty/gnonative",
-      "version": "0.1.0",
+      "name": "@gnolang/gnonative",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20240327143536-1ec48ff39f30.2",

--- a/expo/package.json
+++ b/expo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@berty/gnonative",
+  "name": "@gnolang/gnonative",
   "version": "0.1.2",
   "description": "Develop for Gno using your app's native language ",
   "main": "build/index.js",


### PR DESCRIPTION
This PR should fix the semantic release CI Job, but we also have to set up the NPM_TOKEN secret in the repo to get it working.

We split some rules in the main Makefile to be able to compile only the Go framework without other unnecessary stuff.