### PR TITLE
refactor: Rename the React Context Provider to GnoNativeProvider

### DIFF
--- a/expo/example/App.tsx
+++ b/expo/example/App.tsx
@@ -1,4 +1,4 @@
-import { GnokeyProvider, useGnokeyContext } from '@gnolang/gnonative';
+import { GnoNativeProvider, useGnoNativeContext } from '@gnolang/gnonative';
 import React, { useEffect, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
@@ -9,14 +9,14 @@ const config = {
 
 export default function App() {
   return (
-    <GnokeyProvider config={config}>
+    <GnoNativeProvider config={config}>
       <InnerApp />
-    </GnokeyProvider>
+    </GnoNativeProvider>
   );
 }
 
 const InnerApp = () => {
-  const gno = useGnokeyContext();
+  const gno = useGnoNativeContext();
   const [greeting, setGreeting] = useState('');
 
   useEffect(() => {
@@ -24,6 +24,10 @@ const InnerApp = () => {
       try {
         const accounts = await gno.listKeyInfo();
         console.log(accounts);
+
+        const remote = await gno.getRemote();
+        const chainId = await gno.getChainID();
+        console.log('Remote %s ChainId %s', remote, chainId);
 
         setGreeting(await gno.hello('Gno'));
 

--- a/expo/src/index.ts
+++ b/expo/src/index.ts
@@ -17,5 +17,5 @@ export function addChangeListener(listener: (event: ChangeEventPayload) => void)
 
 export { ChangeEventPayload, GnonativeView, GnonativeViewProps };
 export { useGno } from './hooks/use-gno';
-export * from './provider/gnokey-provider';
+export * from './provider/gnonative-provider';
 export * from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';

--- a/expo/src/provider/gnonative-provider.tsx
+++ b/expo/src/provider/gnonative-provider.tsx
@@ -47,8 +47,8 @@ import { GoBridge } from '../GoBridge';
 import * as Grpc from '../grpc/client';
 import { GnoAccount } from '../hooks/types';
 
-export interface GnokeyContextProps {
-  initGnokey: (config: ConfigProps) => Promise<boolean>;
+export interface GnoNativeContextProps {
+  init: (config: ConfigProps) => Promise<boolean>;
 
   setRemote: (remote: string) => Promise<SetRemoteResponse>;
   getRemote: () => Promise<string>;
@@ -109,7 +109,7 @@ interface ConfigProps {
   chain_id: string;
 }
 
-interface GnokeyProviderProps {
+interface GnoNativeProviderProps {
   config: ConfigProps;
   children: React.ReactNode;
 }
@@ -120,9 +120,9 @@ enum BridgeStatus {
   Started,
 }
 
-const GnokeyContext = createContext<GnokeyContextProps | null>(null);
+const GnoNativeContext = createContext<GnoNativeContextProps | null>(null);
 
-const GnokeyProvider: React.FC<GnokeyProviderProps> = ({ children, config }) => {
+const GnoNativeProvider: React.FC<GnoNativeProviderProps> = ({ children, config }) => {
   const [initialized, setInitialized] = useState(false);
   const [clientInstance, setClientInstance] = useState<
     PromiseClient<typeof GnoNativeService> | undefined
@@ -131,14 +131,14 @@ const GnokeyProvider: React.FC<GnokeyProviderProps> = ({ children, config }) => 
 
   useEffect(() => {
     (async () => {
-      await initGnokey(config);
+      await init(config);
       setInitialized(true);
     })();
   }, []);
 
-  async function initGnokey(config): Promise<boolean> {
+  async function init(config): Promise<boolean> {
     console.log(
-      '🍄 Initializing Gnokey on remote: %s chain_id: %s',
+      '🍄 Initializing GnoNative on remote: %s chain_id: %s',
       config.remote,
       config.chain_id,
     );
@@ -160,10 +160,10 @@ const GnokeyProvider: React.FC<GnokeyProviderProps> = ({ children, config }) => 
     console.log('GoBridge GRPC client instance. Done.');
 
     try {
-      await client.setRemote(new SetRemoteRequest({ remote: 'gno.land:26657' }));
-      await client.setChainID(new SetChainIDRequest({ chainId: 'portal-loop' }));
+      await client.setRemote(new SetRemoteRequest({ remote: config.remote }));
+      await client.setChainID(new SetChainIDRequest({ chainId: config.chain_id }));
 
-      console.log('✅ Gnokey bridge initialized.');
+      console.log('✅ GnoNative bridge initialized.');
     } catch (error) {
       console.error(error);
       return false;
@@ -435,7 +435,7 @@ const GnokeyProvider: React.FC<GnokeyProviderProps> = ({ children, config }) => 
   };
 
   const value = {
-    initGnokey,
+    init,
     setRemote,
     getRemote,
     setChainID,
@@ -470,16 +470,16 @@ const GnokeyProvider: React.FC<GnokeyProviderProps> = ({ children, config }) => 
     return null;
   }
 
-  return <GnokeyContext.Provider value={value}>{children}</GnokeyContext.Provider>;
+  return <GnoNativeContext.Provider value={value}>{children}</GnoNativeContext.Provider>;
 };
 
-function useGnokeyContext() {
-  const context = useContext(GnokeyContext) as GnokeyContextProps;
+function useGnoNativeContext() {
+  const context = useContext(GnoNativeContext) as GnoNativeContextProps;
 
   if (context === undefined) {
-    throw new Error('useGnokeyContext must be used within a GnokeyProvider');
+    throw new Error('useGnoNativeContext must be used within a GnoNativeProvider');
   }
   return context;
 }
 
-export { useGnokeyContext, GnokeyProvider };
+export { useGnoNativeContext, GnoNativeProvider };


### PR DESCRIPTION
This pull request renames the React Context Provider from GnokeyProvider to GnoNativeProvider. The changes include updating the import statements, renaming the component, and updating the references throughout the codebase. This change improves the clarity and consistency of the codebase.