### PR TITLE
chore: In NewBridge, for UseTcpListener, use addr localhost:0

### DIFF
--- a/framework/service/bridge.go
+++ b/framework/service/bridge.go
@@ -70,6 +70,7 @@ func NewBridge(config *BridgeConfig) (*Bridge, error) {
 
 		if config.UseTcpListener {
 			svcOpts = append(svcOpts, service.WithUseTcpListener())
+			svcOpts = append(svcOpts, service.WithTcpAddr("localhost:0"))
 		}
 
 		if config.DisableUdsListener {


### PR DESCRIPTION
Using localhost:0 make the OS select an available port. Fixes #142
Tested on Android and iOS simulators, able to launch both gnoboard and dSocial (which both create their own GnoNative gRPC server).