### PR TITLE
fix: ignore simulator iOS Framework to save space

### DIFF
--- a/expo/.npmignore
+++ b/expo/.npmignore
@@ -9,3 +9,4 @@ __tests__
 /android/src/test/
 /android/build/
 /example/
+/ios/Frameworks/GnoCore.xcframework/ios-arm64_x86_64-simulator/GnoCore.framework/Versions


### PR DESCRIPTION
The NPM package reached the size limit so we decided to remove a duplicate Framework in the iOS version.