### PR TITLE
fix: increase the semantic release CI job that timeout sometime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   semantic-release:
     runs-on: macos-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Sometime the Semantic Release CI job timeouts, maybe to dependancies download. So we want to increase the timeout to avoid that.