### PR TITLE
chore: In expo GnonativeModule for Android, handle event OnDestroy

### DIFF
--- a/expo/android/src/main/java/land/gno/gnonative/GnonativeModule.kt
+++ b/expo/android/src/main/java/land/gno/gnonative/GnonativeModule.kt
@@ -35,6 +35,17 @@ class GnonativeModule : Module() {
       rootDir = context!!.filesDir
     }
 
+    OnDestroy {
+      try {
+        if (bridgeGnoNative != null) {
+          bridgeGnoNative?.close()
+          bridgeGnoNative = null
+        }
+      } catch (err: Exception) {
+        Log.d("Error: OnDestroy", err.toString())
+      }
+    }
+
     // Defines event names that the module can send to JavaScript.
     Events("onChange")
 


### PR DESCRIPTION
In the expo `GnonativeModule` for iOS, we already handle the `OnDestroy` event. For consistency, this PR updates Android to also handle the `OnDestroy` event.

Note: In my testing, I have not been able to get the app to invoke the `OnDestroy` event, on Android or iOS. On Android, I am able to get the app to invoke the `OnActivityDestroys` event, but this is for an activity, not the module (and is not symmetric with the module `OnCreate`). 