### PR TITLE
chore: In goserver, use the Berty node api.gno.berty.io

### DIFF
--- a/goserver/main.go
+++ b/goserver/main.go
@@ -40,7 +40,7 @@ func runMain(args []string) error {
 		fs = flag.NewFlagSet("goserver", flag.ContinueOnError)
 	}
 
-	fs.StringVar(&remote, "remote", "http://testnet.gno.berty.io:36657", "address of the Gno node")
+	fs.StringVar(&remote, "remote", "https://api.gno.berty.io:443", "address of the Gno node")
 
 	var root *ffcli.Command
 	{


### PR DESCRIPTION
This is the node for dSocial. It is more reliable as a test node.