### PR TITLE
chore: exposing ErrCode class

### DIFF
--- a/expo/android/src/main/java/land/gno/gnonative/GoBridgeError.kt
+++ b/expo/android/src/main/java/land/gno/gnonative/GoBridgeError.kt
@@ -2,5 +2,4 @@ package land.gno.gnonative
 import expo.modules.kotlin.exception.CodedException
 
 class GoBridgeNotStartedError : CodedException("NotStarted", "Service hasn't started yet", null)
-class GoBridgeCoreError(err: Exception?) : CodedException("CoreError", err)
 class GoBridgeCoreEOF : CodedException("EOF", "EOF", null)

--- a/expo/android/src/main/java/land/gno/gnonative/JavaPromiseBlock.kt
+++ b/expo/android/src/main/java/land/gno/gnonative/JavaPromiseBlock.kt
@@ -26,7 +26,8 @@ class PromiseBlock(val promise: Promise): IPromiseBlock {
     if (err?.message == "EOF") {
       this.promise.reject(GoBridgeCoreEOF())
     } else {
-      this.promise.reject(GoBridgeCoreError(err))
+      // Only the reject()'s message argument will be thrown to React Native, so put the error message in.
+      this.promise.reject("invoke method error", err?.message, null)
     }
 
     this.remove() // cleanup the promise

--- a/expo/src/grpc/error.ts
+++ b/expo/src/grpc/error.ts
@@ -86,4 +86,4 @@ class GRPCError extends Error {
   }
 }
 
-export { GRPCError };
+export { GRPCError, ErrCode };

--- a/expo/src/index.ts
+++ b/expo/src/index.ts
@@ -18,7 +18,7 @@ export function addChangeListener(listener: (event: ChangeEventPayload) => void)
 export { ChangeEventPayload, GnonativeView, GnonativeViewProps };
 export * from './provider/gnonative-provider';
 export * from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
-
-export * from './grpc/error';
+export * from '@buf/gnolang_gnonative.bufbuild_es/rpc_pb';
+export { GRPCError } from './grpc/error';
 
 export * from './api/GnoNativeApi';

--- a/expo/src/index.ts
+++ b/expo/src/index.ts
@@ -18,5 +18,6 @@ export function addChangeListener(listener: (event: ChangeEventPayload) => void)
 export { ChangeEventPayload, GnonativeView, GnonativeViewProps };
 export * from './provider/gnonative-provider';
 export * from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
+export * from '@buf/gnolang_gnonative.bufbuild_es/rpc_pb';
 
 export * from './api/GnoNativeApi';

--- a/expo/src/index.ts
+++ b/expo/src/index.ts
@@ -18,6 +18,7 @@ export function addChangeListener(listener: (event: ChangeEventPayload) => void)
 export { ChangeEventPayload, GnonativeView, GnonativeViewProps };
 export * from './provider/gnonative-provider';
 export * from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
-export * from '@buf/gnolang_gnonative.bufbuild_es/rpc_pb';
+
+export * from './grpc/error';
 
 export * from './api/GnoNativeApi';


### PR DESCRIPTION
Expose ErrCode class and add rpc_pb to exports.
Useful for client who wants to implements error checks on their dApps, eg:

```
import { ErrCode } from "@gnolang/gnonative";  

if (err.errCode() === ErrCode.ErrDecryptionFailed) {
  setError("Wrong password, please try again.");
}
```