### PR TITLE
chore: In api.go, fix doc comment for file locations

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -1,5 +1,5 @@
-// This file implements the gRPC API methods defined in service/rpc/api_gen.proto . For documentation,
-// see that file and related request/response fields in the generated gnonativetypes.proto .
+// This file implements the gRPC API methods defined in api/rpc.proto . For documentation,
+// see that file and related request/response fields in the generated api/gnonativetypes.proto .
 
 package service
 


### PR DESCRIPTION
The file structure was changed in PR https://github.com/gnolang/gnonative/pull/92 . This PR is a followup to fix the file location in the doc comment for api.go .