### PR TITLE
chore: In `GnoNativeService` interface, add methods needed by Gnokey Mobile

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -61,7 +61,7 @@ func (s *gnoNativeService) GenerateRecoveryPhrase(ctx context.Context, req *conn
 	return connect.NewResponse(&api_gen.GenerateRecoveryPhraseResponse{Phrase: phrase}), nil
 }
 
-func convertKeyInfo(key crypto_keys.Info) (*api_gen.KeyInfo, error) {
+func ConvertKeyInfo(key crypto_keys.Info) (*api_gen.KeyInfo, error) {
 	return &api_gen.KeyInfo{
 		Type:    uint32(key.GetType()),
 		Name:    key.GetName(),
@@ -81,7 +81,7 @@ func (s *gnoNativeService) ListKeyInfo(ctx context.Context, req *connect.Request
 	formatedKeys := make([]*api_gen.KeyInfo, 0)
 
 	for _, key := range keys {
-		info, err := convertKeyInfo(key)
+		info, err := ConvertKeyInfo(key)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +133,7 @@ func (s *gnoNativeService) GetKeyInfoByName(ctx context.Context, req *connect.Re
 		return nil, getGrpcError(err)
 	}
 
-	info, err := convertKeyInfo(key)
+	info, err := ConvertKeyInfo(key)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (s *gnoNativeService) GetKeyInfoByAddress(ctx context.Context, req *connect
 		return nil, getGrpcError(err)
 	}
 
-	info, err := convertKeyInfo(key)
+	info, err := ConvertKeyInfo(key)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (s *gnoNativeService) GetKeyInfoByNameOrAddress(ctx context.Context, req *c
 		return nil, getGrpcError(err)
 	}
 
-	info, err := convertKeyInfo(key)
+	info, err := ConvertKeyInfo(key)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +181,7 @@ func (s *gnoNativeService) CreateAccount(ctx context.Context, req *connect.Reque
 		return nil, getGrpcError(err)
 	}
 
-	info, err := convertKeyInfo(key)
+	info, err := ConvertKeyInfo(key)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,7 @@ func (s *gnoNativeService) SelectAccount(ctx context.Context, req *connect.Reque
 		return nil, getGrpcError(err)
 	}
 
-	info, err := convertKeyInfo(key)
+	info, err := ConvertKeyInfo(key)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (s *gnoNativeService) GetActiveAccount(ctx context.Context, req *connect.Re
 		return nil, api_gen.ErrCode_ErrNoActiveAccount
 	}
 
-	info, err := convertKeyInfo(account.keyInfo)
+	info, err := ConvertKeyInfo(account.keyInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/service/api.go
+++ b/service/api.go
@@ -34,7 +34,11 @@ func (s *gnoNativeService) SetRemote(ctx context.Context, req *connect.Request[a
 }
 
 func (s *gnoNativeService) GetRemote(ctx context.Context, req *connect.Request[api_gen.GetRemoteRequest]) (*connect.Response[api_gen.GetRemoteResponse], error) {
-	return connect.NewResponse(&api_gen.GetRemoteResponse{Remote: s.remote}), nil
+	return connect.NewResponse(&api_gen.GetRemoteResponse{Remote: s.ClientGetRemote()}), nil
+}
+
+func (s *gnoNativeService) ClientGetRemote() string {
+	return s.remote
 }
 
 func (s *gnoNativeService) SetChainID(ctx context.Context, req *connect.Request[api_gen.SetChainIDRequest]) (*connect.Response[api_gen.SetChainIDResponse], error) {
@@ -73,7 +77,7 @@ func ConvertKeyInfo(key crypto_keys.Info) (*api_gen.KeyInfo, error) {
 func (s *gnoNativeService) ListKeyInfo(ctx context.Context, req *connect.Request[api_gen.ListKeyInfoRequest]) (*connect.Response[api_gen.ListKeyInfoResponse], error) {
 	s.logger.Debug("ListKeyInfo called")
 
-	keys, err := s.getSigner().Keybase.List()
+	keys, err := s.ClientListKeyInfo()
 	if err != nil {
 		return nil, err
 	}
@@ -90,6 +94,10 @@ func (s *gnoNativeService) ListKeyInfo(ctx context.Context, req *connect.Request
 	}
 
 	return connect.NewResponse(&api_gen.ListKeyInfoResponse{Keys: formatedKeys}), nil
+}
+
+func (s *gnoNativeService) ClientListKeyInfo() ([]crypto_keys.Info, error) {
+	return s.getSigner().Keybase.List()
 }
 
 func (s *gnoNativeService) HasKeyByName(ctx context.Context, req *connect.Request[api_gen.HasKeyByNameRequest]) (*connect.Response[api_gen.HasKeyByNameResponse], error) {
@@ -351,14 +359,14 @@ func (s *gnoNativeService) Call(ctx context.Context, req *connect.Request[api_ge
 		s.logger.Debug("Call", zap.String("package", msg.PackagePath), zap.String("function", msg.Fnc), zap.Any("args", msg.Args))
 	}
 
+	cfg, msgs := convertCallRequest(req.Msg)
+
 	s.lock.RLock()
 	if s.activeAccount == nil {
 		s.lock.RUnlock()
 		return api_gen.ErrCode_ErrNoActiveAccount
 	}
 	s.lock.RUnlock()
-
-	cfg, msgs := convertCallRequest(req.Msg)
 
 	bres, err := s.client.Call(*cfg, msgs...)
 	if err != nil {
@@ -556,19 +564,12 @@ func (s *gnoNativeService) MakeRunTx(ctx context.Context, req *connect.Request[a
 }
 
 func (s *gnoNativeService) SignTx(ctx context.Context, req *connect.Request[api_gen.SignTxRequest]) (*connect.Response[api_gen.SignTxResponse], error) {
-	s.lock.RLock()
-	if s.activeAccount == nil {
-		s.lock.RUnlock()
-		return nil, api_gen.ErrCode_ErrNoActiveAccount
-	}
-	s.lock.RUnlock()
-
 	var tx std.Tx
 	if err := amino.UnmarshalJSON([]byte(req.Msg.TxJson), &tx); err != nil {
 		return nil, err
 	}
 
-	signedTx, err := s.client.SignTx(tx, req.Msg.AccountNumber, req.Msg.SequenceNumber)
+	signedTx, err := s.ClientSignTx(tx, req.Msg.AccountNumber, req.Msg.SequenceNumber)
 	if err != nil {
 		return nil, getGrpcError(err)
 	}
@@ -578,6 +579,17 @@ func (s *gnoNativeService) SignTx(ctx context.Context, req *connect.Request[api_
 		return nil, err
 	}
 	return connect.NewResponse(&api_gen.SignTxResponse{SignedTxJson: string(signedTxJSON)}), nil
+}
+
+func (s *gnoNativeService) ClientSignTx(tx std.Tx, accountNumber, sequenceNumber uint64) (*std.Tx, error) {
+	s.lock.RLock()
+	if s.activeAccount == nil {
+		s.lock.RUnlock()
+		return nil, api_gen.ErrCode_ErrNoActiveAccount
+	}
+	s.lock.RUnlock()
+
+	return s.client.SignTx(tx, accountNumber, sequenceNumber)
 }
 
 func (s *gnoNativeService) BroadcastTxCommit(ctx context.Context, req *connect.Request[api_gen.BroadcastTxCommitRequest],

--- a/service/service.go
+++ b/service/service.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gnolang/gno/gno.land/pkg/gnoclient"
 	rpcclient "github.com/gnolang/gno/tm2/pkg/bft/rpc/client"
 	"github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	crypto_keys "github.com/gnolang/gno/tm2/pkg/crypto/keys"
+	"github.com/gnolang/gno/tm2/pkg/std"
 	api_gen "github.com/gnolang/gnonative/api/gen/go"
 	"github.com/gnolang/gnonative/api/gen/go/_goconnect"
 	"github.com/pkg/errors"
@@ -29,6 +31,11 @@ type GnoNativeService interface {
 	GetUDSPath() string
 	GetTcpAddr() string
 	GetTcpPort() int
+	ClientGetRemote() string
+	// Use the configured gnoclient to call the signer's Keybase.List
+	ClientListKeyInfo() ([]crypto_keys.Info, error)
+	// Use the configured gnoclient to call SignTx
+	ClientSignTx(tx std.Tx, accountNumber, sequenceNumber uint64) (*std.Tx, error)
 
 	io.Closer
 }


### PR DESCRIPTION
The Gnokey Mobile service has a pointer to the local Gno Native Kit service so that it can perform functions with direct Go calls. This PR updates `GnoNativeService` to expose functions needed by Gnokey Mobile (without changing functionality). This PR has two commits:
* In api.go, make `ConvertKeyInfo` a public helper function so that Gnokey Mobile can use it.
* In the `GnoNativeService` interface, add `ClientGetRemote`, `ClientListKeyInfo` and `ClientSignTx`. In `gnoNativeService`, implement these and update `GetRemote`, `ListKeyInfo` and `SignTx` to use them.