### PR TITLE
fix: In GnoNativeApi, add missing updatePassword

### DIFF
--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -40,6 +40,8 @@ import {
   SetPasswordResponse,
   SetRemoteRequest,
   SetRemoteResponse,
+  UpdatePasswordRequest,
+  UpdatePasswordResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 import { GnoNativeService } from '@buf/gnolang_gnonative.connectrpc_es/rpc_connect';
 import { PromiseClient } from '@connectrpc/connect';
@@ -225,6 +227,12 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   async setPassword(password: string): Promise<SetPasswordResponse> {
     const client = await this.#getClient();
     const response = await client.setPassword(new SetPasswordRequest({ password }));
+    return response;
+  }
+
+  async updatePassword(newPassword: string): Promise<UpdatePasswordResponse> {
+    const client = await this.#getClient();
+    const response = await client.setPassword(new UpdatePasswordRequest({ newPassword }));
     return response;
   }
 

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -10,6 +10,7 @@ import {
   SetChainIDResponse,
   SetPasswordResponse,
   SetRemoteResponse,
+  UpdatePasswordResponse,
   KeyInfo,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 
@@ -46,6 +47,7 @@ export interface GnoKeyApi {
   getKeyInfoByNameOrAddress: (nameOrBech32: string) => Promise<KeyInfo | undefined>;
   selectAccount: (nameOrBech32: string) => Promise<SelectAccountResponse>;
   setPassword: (password: string) => Promise<SetPasswordResponse>;
+  updatePassword: (password: string) => Promise<UpdatePasswordResponse>;
   getActiveAccount: () => Promise<GetActiveAccountResponse>;
   queryAccount: (address: Uint8Array) => Promise<QueryAccountResponse>;
   deleteAccount: (


### PR DESCRIPTION
The previous PR added UpdatePassword to the gRPC API, but we also need to add it to GnoNativeApi so that it is available in the NPM provider. (This is a "fix" PR, so it should automatically upload a new NPM.)