### PR TITLE
fix: In expo, update @buf/gnolang_gnonative.bufbuild_es

### DIFF
--- a/expo/package-lock.json
+++ b/expo/package-lock.json
@@ -2464,25 +2464,25 @@
       "peer": true
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.10.0-20240722123703-a858ea7341d6.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.10.0-20240722123703-a858ea7341d6.1.tgz",
+      "version": "1.10.0-20240823100935-4e85c7c00df1.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.10.0-20240823100935-4e85c7c00df1.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es": {
-      "version": "1.4.0-20240722123703-a858ea7341d6.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240722123703-a858ea7341d6.3.tgz",
+      "version": "1.4.0-20240823100935-4e85c7c00df1.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240823100935-4e85c7c00df1.3.tgz",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240722123703-a858ea7341d6.2"
+        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240823100935-4e85c7c00df1.2"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.4.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es/node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.7.2-20240722123703-a858ea7341d6.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240722123703-a858ea7341d6.2.tgz",
+      "version": "1.7.2-20240823100935-4e85c7c00df1.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240823100935-4e85c7c00df1.2.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.7.2"
       }

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -232,7 +232,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
 
   async updatePassword(newPassword: string): Promise<UpdatePasswordResponse> {
     const client = await this.#getClient();
-    const response = await client.setPassword(new UpdatePasswordRequest({ newPassword }));
+    const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword }));
     return response;
   }
 


### PR DESCRIPTION
This is a fix to PR #166 . We need to update @buf/gnolang_gnonative.bufbuild_es . In expo, I entered:
```
npm install @buf/gnolang_gnonative.bufbuild_es
npm install @buf/gnolang_gnonative.connectrpc_es
```

Now, `make npm.pack` succeeds, and Semantic Release should be able to upload the new NPM.

(This PR also fixes a typo in GnoNativeAPI.ts from PR #167 .)