### PR TITLE
chore: In gnoNativeService.userAccounts, use bech32 for the key

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -61,7 +61,7 @@ type gnoNativeService struct {
 	useGnokeyMobile    bool
 	gnokeyMobileClient gnokey_mobile_goconnect.GnokeyMobileServiceClient
 
-	// Map of key name to userAccount.
+	// Map of key bech32 to userAccount.
 	userAccounts map[string]*userAccount
 	// The active account in userAccounts, or nil if none
 	activeAccount *userAccount


### PR DESCRIPTION
`gnoNativeService.userAccounts` is a map used to track all the user accounts which have been selected, including their password. Currently, the map key is either the [account name or the bech32 address](https://github.com/gnolang/gnonative/blob/44852235c93c78ff30680e16ec0665dddca987d8/service/api.go#L235). We want to rely on `gnoNativeService.userAccounts` where we only know the account address (not the name). For example, to sign a transaction with any key that has been selected, known only by its address. This PR standardizes the key of `gnoNativeService.userAccounts` to only be the bech32 address:

* In `SelectAccount`, store the account info in `gnoNativeService.userAccounts` using the bech32. (This is backwards compatible, even if the application calls `SelectAccount` to select by name. No changes needed to the app.)
* In `DeleteAccount`, first fetch the key from the Keybase so that we know its address. When checking if the deleted account was the active account, use the bech32. (This is backwards compatible, even if the application calls `DeleteAccount` to delete by name.)