### PR TITLE
feat: Update expo to use any activated account

### DIFF
--- a/expo/package-lock.json
+++ b/expo/package-lock.json
@@ -2464,25 +2464,25 @@
       "peer": true
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.10.0-20240823100935-4e85c7c00df1.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.10.0-20240823100935-4e85c7c00df1.1.tgz",
+      "version": "1.10.0-20240903123231-19f0013c32a6.1",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.10.0-20240903123231-19f0013c32a6.1.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es": {
-      "version": "1.4.0-20240823100935-4e85c7c00df1.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240823100935-4e85c7c00df1.3.tgz",
+      "version": "1.4.0-20240903123231-19f0013c32a6.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240903123231-19f0013c32a6.3.tgz",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240823100935-4e85c7c00df1.2"
+        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240903123231-19f0013c32a6.2"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.4.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es/node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.7.2-20240823100935-4e85c7c00df1.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240823100935-4e85c7c00df1.2.tgz",
+      "version": "1.7.2-20240903123231-19f0013c32a6.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240903123231-19f0013c32a6.2.tgz",
       "peerDependencies": {
         "@bufbuild/protobuf": "^1.7.2"
       }

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -10,6 +10,8 @@ import {
   GenerateRecoveryPhraseRequest,
   GetActiveAccountRequest,
   GetActiveAccountResponse,
+  GetActivatedAccountRequest,
+  GetActivatedAccountResponse,
   GetChainIDRequest,
   GetKeyInfoByAddressRequest,
   GetKeyInfoByNameOrAddressRequest,
@@ -32,6 +34,8 @@ import {
   RenderRequest,
   SelectAccountRequest,
   SelectAccountResponse,
+  ActivateAccountRequest,
+  ActivateAccountResponse,
   SendRequest,
   SendResponse,
   SetChainIDRequest,
@@ -213,6 +217,16 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     return response;
   }
 
+  async activateAccount(nameOrBech32: string): Promise<ActivateAccountResponse> {
+    const client = await this.#getClient();
+    const response = await client.activateAccount(
+      new ActivateAccountRequest({
+        nameOrBech32,
+      }),
+    );
+    return response;
+  }
+
   async getClient(): Promise<PromiseClient<typeof GnoNativeService>> {
     if (!this.clientInstance) {
       throw new Error('GoBridge client instance not initialized.');
@@ -224,21 +238,27 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     return this.clientInstance !== undefined;
   }
 
-  async setPassword(password: string): Promise<SetPasswordResponse> {
+  async setPassword(password: string, address?: Uint8Array): Promise<SetPasswordResponse> {
     const client = await this.#getClient();
-    const response = await client.setPassword(new SetPasswordRequest({ password }));
+    const response = await client.setPassword(new SetPasswordRequest({ password, address }));
     return response;
   }
 
-  async updatePassword(newPassword: string): Promise<UpdatePasswordResponse> {
+  async updatePassword(newPassword: string, address?: Uint8Array): Promise<UpdatePasswordResponse> {
     const client = await this.#getClient();
-    const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword }));
+    const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword, address }));
     return response;
   }
 
   async getActiveAccount(): Promise<GetActiveAccountResponse> {
     const client = await this.#getClient();
     const response = await client.getActiveAccount(new GetActiveAccountRequest());
+    return response;
+  }
+
+  async getActivatedAccount(): Promise<GetActivatedAccountResponse> {
+    const client = await this.#getClient();
+    const response = await client.getActivatedAccount(new GetActivatedAccountRequest());
     return response;
   }
 
@@ -303,6 +323,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     args: string[],
     gasFee: string,
     gasWanted: number,
+    callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
   ): Promise<AsyncIterable<CallResponse>> {
@@ -312,6 +333,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
         gasFee,
         gasWanted: BigInt(gasWanted),
         memo,
+        callerAddress,
         msgs: [
           new MsgCall({
             packagePath,
@@ -330,6 +352,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     send: string,
     gasFee: string,
     gasWanted: number,
+    callerAddress?: Uint8Array,
     memo?: string,
   ): Promise<AsyncIterable<SendResponse>> {
     const client = await this.#getClient();
@@ -338,6 +361,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
         gasFee,
         gasWanted: BigInt(gasWanted),
         memo,
+        callerAddress,
         msgs: [
           new MsgSend({
             toAddress,

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -2,10 +2,12 @@ import {
   CallResponse,
   DeleteAccountResponse,
   GetActiveAccountResponse,
+  GetActivatedAccountResponse,
   HelloStreamResponse,
   QueryAccountResponse,
   QueryResponse,
   SelectAccountResponse,
+  ActivateAccountResponse,
   SendResponse,
   SetChainIDResponse,
   SetPasswordResponse,
@@ -46,9 +48,11 @@ export interface GnoKeyApi {
   getKeyInfoByAddress: (address: Uint8Array) => Promise<KeyInfo | undefined>;
   getKeyInfoByNameOrAddress: (nameOrBech32: string) => Promise<KeyInfo | undefined>;
   selectAccount: (nameOrBech32: string) => Promise<SelectAccountResponse>;
-  setPassword: (password: string) => Promise<SetPasswordResponse>;
-  updatePassword: (password: string) => Promise<UpdatePasswordResponse>;
+  activateAccount: (nameOrBech32: string) => Promise<ActivateAccountResponse>;
+  setPassword: (password: string, address?: Uint8Array) => Promise<SetPasswordResponse>;
+  updatePassword: (password: string, address?: Uint8Array) => Promise<UpdatePasswordResponse>;
   getActiveAccount: () => Promise<GetActiveAccountResponse>;
+  getActivatedAccount: () => Promise<GetActivatedAccountResponse>;
   queryAccount: (address: Uint8Array) => Promise<QueryAccountResponse>;
   deleteAccount: (
     nameOrBech32: string,
@@ -64,6 +68,7 @@ export interface GnoKeyApi {
     args: string[],
     gasFee: string,
     gasWanted: number,
+    callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
   ) => Promise<AsyncIterable<CallResponse>>;
@@ -72,6 +77,7 @@ export interface GnoKeyApi {
     send: string,
     gasFee: string,
     gasWanted: number,
+    callerAddress?: Uint8Array,
     memo?: string,
   ) => Promise<AsyncIterable<SendResponse>>;
   addressToBech32: (address: Uint8Array) => Promise<string>;

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	connectrpc.com/grpchealth v1.3.0
 	connectrpc.com/grpcreflect v1.2.0
 	github.com/gnolang/gno v0.1.2-0.20240826090356-651f5aac3706
-	github.com/gnolang/gnokey-mobile v0.0.0-20240814140149-eb333b936c7c
+	github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6
 	github.com/oklog/run v1.1.0
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/peterbourgon/unixtransport v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/gnolang/gno v0.1.2-0.20240826090356-651f5aac3706 h1:0kpoNeuErRec3JOt3
 github.com/gnolang/gno v0.1.2-0.20240826090356-651f5aac3706/go.mod h1:dBaL1Au2MNLol+3FXdCv+IKLJnMKtTmIt778zsKjVu0=
 github.com/gnolang/gnokey-mobile v0.0.0-20240814140149-eb333b936c7c h1:rL7dVjWOpdQxmbsh69HrgAklolhydTZmPvgo6BpgdhE=
 github.com/gnolang/gnokey-mobile v0.0.0-20240814140149-eb333b936c7c/go.mod h1:2NrHp15t6QXGNDruOpw6/xN6z50kquVvZs6uxvUNhsQ=
+github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6 h1:D4dctoTOCk30fbMebwgDYRhcemXrcK7vqjl6MFPUIfc=
+github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6/go.mod h1:fD0uCByVS8JKxQbSPOvJxO0s7vdfh1BBXBcv8d+ApDk=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:xJhtEL7ahjM1WJipt89gel8tHzfIl/LyMY+lCYh38d8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=


### PR DESCRIPTION
PR https://github.com/gnolang/gnonative/pull/172 update the API to support using any activated account. We need to update the expo provider to the same API. This PR has 3 commits:

1. Update go.mod to use the latest gnokey-mobile following changes in PR https://github.com/gnolang/gnokey-mobile/pull/9
2. In expo, npm install the latest gnolang_gnonative.bufbuild_es and connectrpc_es to access the new API
3. Update expo/src/api/GnoNativeApi.ts to match the new API to use any activated account, specified by address. Note that the address parameters are optional for temporary backwards compatibility. When dSocial and Gnokey Mobile are updated to use the new API and specify the address, we will do a PR to require the address parameter, and to remove the deprecated `selectAccount` and `getActiveAccount`.