### PR TITLE
fix: update gnonative API

### DIFF
--- a/expo/package-lock.json
+++ b/expo/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "^1.10.0-20240722123703-a858ea7341d6.1",
-        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240722123703-a858ea7341d6.3",
+        "@buf/gnolang_gnonative.bufbuild_es": "^1.7.2-20240919093120-8280c8c152be.2",
+        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240919093120-8280c8c152be.3",
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",
@@ -2464,27 +2464,20 @@
       "peer": true
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.10.0-20240903123231-19f0013c32a6.1",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.10.0-20240903123231-19f0013c32a6.1.tgz",
+      "version": "1.7.2-20240919093120-8280c8c152be.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240919093120-8280c8c152be.2.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.10.0"
+        "@bufbuild/protobuf": "^1.7.2"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es": {
-      "version": "1.4.0-20240903123231-19f0013c32a6.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240903123231-19f0013c32a6.3.tgz",
+      "version": "1.4.0-20240919093120-8280c8c152be.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240919093120-8280c8c152be.3.tgz",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240903123231-19f0013c32a6.2"
+        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240919093120-8280c8c152be.2"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.4.0"
-      }
-    },
-    "node_modules/@buf/gnolang_gnonative.connectrpc_es/node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.7.2-20240903123231-19f0013c32a6.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240903123231-19f0013c32a6.2.tgz",
-      "peerDependencies": {
-        "@bufbuild/protobuf": "^1.7.2"
       }
     },
     "node_modules/@bufbuild/protobuf": {

--- a/expo/package.json
+++ b/expo/package.json
@@ -29,8 +29,8 @@
   "license": "MIT",
   "homepage": "https://github.com/gnolang/gnonative#readme",
   "dependencies": {
-    "@buf/gnolang_gnonative.bufbuild_es": "^1.10.0-20240722123703-a858ea7341d6.1",
-    "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240722123703-a858ea7341d6.3",
+    "@buf/gnolang_gnonative.bufbuild_es": "^1.7.2-20240919093120-8280c8c152be.2",
+    "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240919093120-8280c8c152be.3",
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-web": "^1.4.0",


### PR DESCRIPTION
This PR fixes an issue when you want to execute `npm install` in the `expo` folder, that fails with this error:

```bash
src/api/GnoNativeApi.ts:249:91 - error TS2561: Object literal may only specify known properties, but 'addresses' does not exist in type 'PartialMessage<UpdatePasswordRequest>'. Did you mean to write 'address'?

249     const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword, addresses }));
```

It's because we need to update the `gnonative` API that implements the new addresses field in the request.