### PR TITLE
BREAKING CHANGE: add MakeCallTx, SignTx and BroadcastTxCommit in GnoNativeApi

### DIFF
--- a/examples/js/expo/gnoboard/src/GoBridge/types.ts
+++ b/examples/js/expo/gnoboard/src/GoBridge/types.ts
@@ -6,7 +6,7 @@ export type GnoConfig = {
   KeyName: string;
   Password: string;
   GasFee: string;
-  GasWanted: number;
+  GasWanted: bigint;
   Mnemonic: string;
 };
 

--- a/examples/js/expo/gnoboard/src/api/GnoNativeApi.ts
+++ b/examples/js/expo/gnoboard/src/api/GnoNativeApi.ts
@@ -2,6 +2,7 @@ import {
   AddressFromBech32Request,
   AddressToBech32Request,
   AddressFromMnemonicRequest,
+  BroadcastTxCommitResponse,
   CallRequest,
   CallResponse,
   CreateAccountRequest,
@@ -18,11 +19,13 @@ import {
   GetKeyInfoByNameRequest,
   GetRemoteRequest,
   HasKeyByAddressRequest,
+  HasKeyByNameOrAddressRequest,
   HasKeyByNameRequest,
   HelloRequest,
   HelloStreamResponse,
   KeyInfo,
   ListKeyInfoRequest,
+  MakeTxResponse,
   MsgCall,
   MsgSend,
   QEvalRequest,
@@ -43,6 +46,7 @@ import {
   SetPasswordResponse,
   SetRemoteRequest,
   SetRemoteResponse,
+  SignTxResponse,
   UpdatePasswordRequest,
   UpdatePasswordResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
@@ -81,7 +85,9 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
 
     try {
       await this.clientInstance.setRemote(new SetRemoteRequest({ remote: this.config.remote }));
-      await this.clientInstance.setChainID(new SetChainIDRequest({ chainId: this.config.chain_id }));
+      await this.clientInstance.setChainID(
+        new SetChainIDRequest({ chainId: this.config.chain_id }),
+      );
       console.log('✅ GnoNative bridge initialized.');
       if (this.config.start_gnokey_mobile_service) {
         await this.startGnokeyMobileService();
@@ -113,31 +119,46 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async setRemote(remote: string): Promise<SetRemoteResponse> {
-    const client = await this.#getClient();
-    const response = await client.setRemote(new SetRemoteRequest({ remote }));
+    const client = this.#getClient();
+    const response = client.setRemote(new SetRemoteRequest({ remote }));
     return response;
   }
 
   async getRemote(): Promise<string> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getRemote(new GetRemoteRequest());
     return response.remote;
   }
 
+  async signTx(
+    txJson: string,
+    address: Uint8Array,
+    accountNumber: bigint = BigInt(0),
+    sequenceNumber: bigint = BigInt(0),
+  ): Promise<SignTxResponse> {
+    const client = this.#getClient();
+    const response = client.signTx({ txJson, address, accountNumber, sequenceNumber });
+    return response;
+  }
+
   async setChainID(chainId: string): Promise<SetChainIDResponse> {
-    const client = await this.#getClient();
-    const response = await client.setChainID(new SetChainIDRequest({ chainId }));
+    const client = this.#getClient();
+    const response = client.setChainID(new SetChainIDRequest({ chainId }));
     return response;
   }
 
   async getChainID() {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getChainID(new GetChainIDRequest());
     return response.chainId;
   }
 
-  async createAccount(nameOrBech32: string, mnemonic: string, password: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+  async createAccount(
+    nameOrBech32: string,
+    mnemonic: string,
+    password: string,
+  ): Promise<KeyInfo | undefined> {
+    const client = this.#getClient();
     const reponse = await client.createAccount(
       new CreateAccountRequest({
         nameOrBech32,
@@ -149,56 +170,88 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async generateRecoveryPhrase() {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.generateRecoveryPhrase(new GenerateRecoveryPhraseRequest());
     return response.phrase;
   }
 
   async hasKeyByName(name: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByName(new HasKeyByNameRequest({ name }));
     return response.has;
   }
 
   async hasKeyByAddress(address: Uint8Array) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByAddress(new HasKeyByAddressRequest({ address }));
     return response.has;
   }
 
   async hasKeyByNameOrAddress(nameOrBech32: string) {
-    const client = await this.#getClient();
-    const response = await client.hasKeyByNameOrAddress(new HasKeyByNameOrAddressRequest({ nameOrBech32 }));
+    const client = this.#getClient();
+    const response = await client.hasKeyByNameOrAddress(
+      new HasKeyByNameOrAddressRequest({ nameOrBech32 }),
+    );
     return response.has;
   }
 
   async getKeyInfoByName(name: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByName(new GetKeyInfoByNameRequest({ name }));
     return response.key;
   }
 
   async getKeyInfoByAddress(address: Uint8Array): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByAddress(new GetKeyInfoByAddressRequest({ address }));
     return response.key;
   }
 
   async getKeyInfoByNameOrAddress(nameOrBech32: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
-    const response = await client.getKeyInfoByNameOrAddress(new GetKeyInfoByNameOrAddressRequest({ nameOrBech32 }));
+    const client = this.#getClient();
+    const response = await client.getKeyInfoByNameOrAddress(
+      new GetKeyInfoByNameOrAddressRequest({ nameOrBech32 }),
+    );
     return response.key;
   }
 
   async listKeyInfo(): Promise<KeyInfo[]> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.listKeyInfo(new ListKeyInfoRequest());
     return response.keys;
   }
 
+  async makeCallTx(
+    packagePath: string,
+    fnc: string,
+    args: string[],
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress?: Uint8Array,
+    send?: string,
+    memo?: string,
+  ): Promise<MakeTxResponse> {
+    const client = this.#getClient();
+    const reponse = client.makeCallTx({
+      gasFee,
+      gasWanted,
+      memo,
+      callerAddress,
+      msgs: [
+        {
+          packagePath,
+          fnc,
+          args,
+          send,
+        },
+      ],
+    });
+    return reponse;
+  }
+
   async selectAccount(nameOrBech32: string): Promise<SelectAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.selectAccount(
+    const client = this.#getClient();
+    const response = client.selectAccount(
       new SelectAccountRequest({
         nameOrBech32,
       }),
@@ -207,8 +260,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async activateAccount(nameOrBech32: string): Promise<ActivateAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.activateAccount(
+    const client = this.#getClient();
+    const response = client.activateAccount(
       new ActivateAccountRequest({
         nameOrBech32,
       }),
@@ -228,38 +281,45 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async setPassword(password: string, address?: Uint8Array): Promise<SetPasswordResponse> {
-    const client = await this.#getClient();
-    const response = await client.setPassword(new SetPasswordRequest({ password, address }));
+    const client = this.#getClient();
+    const response = client.setPassword(new SetPasswordRequest({ password, address }));
     return response;
   }
 
-  async updatePassword(newPassword: string, address?: Uint8Array): Promise<UpdatePasswordResponse> {
-    const client = await this.#getClient();
-    const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword, address }));
+  async updatePassword(
+    newPassword: string,
+    addresses: Uint8Array[],
+  ): Promise<UpdatePasswordResponse> {
+    const client = this.#getClient();
+    const response = client.updatePassword(new UpdatePasswordRequest({ newPassword, addresses }));
     return response;
   }
 
   async getActiveAccount(): Promise<GetActiveAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.getActiveAccount(new GetActiveAccountRequest());
+    const client = this.#getClient();
+    const response = client.getActiveAccount(new GetActiveAccountRequest());
     return response;
   }
 
   async getActivatedAccount(): Promise<GetActivatedAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.getActivatedAccount(new GetActivatedAccountRequest());
+    const client = this.#getClient();
+    const response = client.getActivatedAccount(new GetActivatedAccountRequest());
     return response;
   }
 
   async queryAccount(address: Uint8Array): Promise<QueryAccountResponse> {
-    const client = await this.#getClient();
-    const reponse = await client.queryAccount(new QueryAccountRequest({ address }));
+    const client = this.#getClient();
+    const reponse = client.queryAccount(new QueryAccountRequest({ address }));
     return reponse;
   }
 
-  async deleteAccount(nameOrBech32: string, password: string | undefined, skipPassword: boolean): Promise<DeleteAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.deleteAccount(
+  async deleteAccount(
+    nameOrBech32: string,
+    password: string | undefined,
+    skipPassword: boolean,
+  ): Promise<DeleteAccountResponse> {
+    const client = this.#getClient();
+    const response = client.deleteAccount(
       new DeleteAccountRequest({
         nameOrBech32,
         password,
@@ -270,8 +330,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async query(path: string, data: Uint8Array): Promise<QueryResponse> {
-    const client = await this.#getClient();
-    const reponse = await client.query(
+    const client = this.#getClient();
+    const reponse = client.query(
       new QueryRequest({
         path,
         data,
@@ -281,7 +341,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async render(packagePath: string, args: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.render(
       new RenderRequest({
         packagePath,
@@ -292,7 +352,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async qEval(packagePath: string, expression: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.qEval(
       new QEvalRequest({
         packagePath,
@@ -307,16 +367,16 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     fnc: string,
     args: string[],
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
   ): Promise<AsyncIterable<CallResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = client.call(
       new CallRequest({
         gasFee,
-        gasWanted: BigInt(gasWanted),
+        gasWanted,
         memo,
         callerAddress,
         msgs: [
@@ -336,15 +396,15 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     toAddress: Uint8Array,
     send: string,
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     memo?: string,
   ): Promise<AsyncIterable<SendResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = client.send(
       new SendRequest({
         gasFee,
-        gasWanted: BigInt(gasWanted),
+        gasWanted,
         memo,
         callerAddress,
         msgs: [
@@ -359,33 +419,41 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async addressToBech32(address: Uint8Array) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressToBech32(new AddressToBech32Request({ address }));
     return response.bech32Address;
   }
 
   async addressFromMnemonic(mnemonic: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressFromMnemonic(new AddressFromMnemonicRequest({ mnemonic }));
     return response.address;
   }
 
   async addressFromBech32(bech32Address: string) {
-    const client = await this.#getClient();
-    const response = await client.addressFromBech32(new AddressFromBech32Request({ bech32Address }));
+    const client = this.#getClient();
+    const response = await client.addressFromBech32(
+      new AddressFromBech32Request({ bech32Address }),
+    );
     return response.address;
+  }
+
+  async broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>> {
+    const client = this.#getClient();
+    const response = client.broadcastTxCommit({ signedTxJson });
+    return response;
   }
 
   // // debug
   async hello(name: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hello(new HelloRequest({ name }));
     return response.greeting;
   }
 
   // // debug
   async helloStream(name: string): Promise<AsyncIterable<HelloStreamResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     return client.helloStream(new HelloRequest({ name }));
   }
 

--- a/examples/js/expo/gnoboard/src/api/types.ts
+++ b/examples/js/expo/gnoboard/src/api/types.ts
@@ -14,6 +14,9 @@ import {
   SetRemoteResponse,
   UpdatePasswordResponse,
   KeyInfo,
+  SignTxResponse,
+  MakeTxResponse,
+  BroadcastTxCommitResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 
 export enum BridgeStatus {
@@ -50,7 +53,7 @@ export interface GnoKeyApi {
   selectAccount: (nameOrBech32: string) => Promise<SelectAccountResponse>;
   activateAccount: (nameOrBech32: string) => Promise<ActivateAccountResponse>;
   setPassword: (password: string, address?: Uint8Array) => Promise<SetPasswordResponse>;
-  updatePassword: (password: string, address?: Uint8Array) => Promise<UpdatePasswordResponse>;
+  updatePassword: (password: string, addresses: Uint8Array[]) => Promise<UpdatePasswordResponse>;
   getActiveAccount: () => Promise<GetActiveAccountResponse>;
   getActivatedAccount: () => Promise<GetActivatedAccountResponse>;
   queryAccount: (address: Uint8Array) => Promise<QueryAccountResponse>;
@@ -67,7 +70,7 @@ export interface GnoKeyApi {
     fnc: string,
     args: string[],
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
@@ -76,13 +79,30 @@ export interface GnoKeyApi {
     toAddress: Uint8Array,
     send: string,
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     memo?: string,
   ) => Promise<AsyncIterable<SendResponse>>;
   addressToBech32: (address: Uint8Array) => Promise<string>;
   addressFromMnemonic: (mnemonic: string) => Promise<Uint8Array>;
   addressFromBech32: (bech32Address: string) => Promise<Uint8Array>;
+  signTx(
+    txJson: string,
+    address: Uint8Array,
+    accountNumber?: bigint,
+    sequenceNumber?: bigint,
+  ): Promise<SignTxResponse>;
+  makeCallTx(
+    packagePath: string,
+    fnc: string,
+    args: string[],
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress?: Uint8Array,
+    send?: string,
+    memo?: string,
+  ): Promise<MakeTxResponse>;
+  broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>>;
   // debug
   hello: (name: string) => Promise<string>;
   helloStream: (name: string) => Promise<AsyncIterable<HelloStreamResponse>>;

--- a/examples/js/expo/gnoboard/src/screens/devmode/index.tsx
+++ b/examples/js/expo/gnoboard/src/screens/devmode/index.tsx
@@ -30,7 +30,7 @@ function DevMode() {
     setLoading('Replying to a post...');
     setAppConsole('replying to a post...');
     const gasFee = '1000000ugnot';
-    const gasWanted = 2000000;
+    const gasWanted = BigInt(2000000);
     const args: Array<string> = ['1', '1', '1', postContent];
     try {
       for await (const response of await gnonative.call('gno.land/r/demo/boards', 'CreateReply', args, gasFee, gasWanted)) {

--- a/examples/js/react-native/hello/GoBridge/types.ts
+++ b/examples/js/react-native/hello/GoBridge/types.ts
@@ -1,4 +1,4 @@
-import { KeyInfo } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
+import {KeyInfo} from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 
 export type GnoConfig = {
   Remote: string;
@@ -6,7 +6,7 @@ export type GnoConfig = {
   KeyName: string;
   Password: string;
   GasFee: string;
-  GasWanted: number;
+  GasWanted: bigint;
   Mnemonic: string;
 };
 

--- a/examples/js/react-native/hello/api/GnoNativeApi.ts
+++ b/examples/js/react-native/hello/api/GnoNativeApi.ts
@@ -2,6 +2,7 @@ import {
   AddressFromBech32Request,
   AddressToBech32Request,
   AddressFromMnemonicRequest,
+  BroadcastTxCommitResponse,
   CallRequest,
   CallResponse,
   CreateAccountRequest,
@@ -18,11 +19,13 @@ import {
   GetKeyInfoByNameRequest,
   GetRemoteRequest,
   HasKeyByAddressRequest,
+  HasKeyByNameOrAddressRequest,
   HasKeyByNameRequest,
   HelloRequest,
   HelloStreamResponse,
   KeyInfo,
   ListKeyInfoRequest,
+  MakeTxResponse,
   MsgCall,
   MsgSend,
   QEvalRequest,
@@ -43,6 +46,7 @@ import {
   SetPasswordResponse,
   SetRemoteRequest,
   SetRemoteResponse,
+  SignTxResponse,
   UpdatePasswordRequest,
   UpdatePasswordResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
@@ -81,7 +85,9 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
 
     try {
       await this.clientInstance.setRemote(new SetRemoteRequest({ remote: this.config.remote }));
-      await this.clientInstance.setChainID(new SetChainIDRequest({ chainId: this.config.chain_id }));
+      await this.clientInstance.setChainID(
+        new SetChainIDRequest({ chainId: this.config.chain_id }),
+      );
       console.log('✅ GnoNative bridge initialized.');
       if (this.config.start_gnokey_mobile_service) {
         await this.startGnokeyMobileService();
@@ -113,31 +119,46 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async setRemote(remote: string): Promise<SetRemoteResponse> {
-    const client = await this.#getClient();
-    const response = await client.setRemote(new SetRemoteRequest({ remote }));
+    const client = this.#getClient();
+    const response = client.setRemote(new SetRemoteRequest({ remote }));
     return response;
   }
 
   async getRemote(): Promise<string> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getRemote(new GetRemoteRequest());
     return response.remote;
   }
 
+  async signTx(
+    txJson: string,
+    address: Uint8Array,
+    accountNumber: bigint = BigInt(0),
+    sequenceNumber: bigint = BigInt(0),
+  ): Promise<SignTxResponse> {
+    const client = this.#getClient();
+    const response = client.signTx({ txJson, address, accountNumber, sequenceNumber });
+    return response;
+  }
+
   async setChainID(chainId: string): Promise<SetChainIDResponse> {
-    const client = await this.#getClient();
-    const response = await client.setChainID(new SetChainIDRequest({ chainId }));
+    const client = this.#getClient();
+    const response = client.setChainID(new SetChainIDRequest({ chainId }));
     return response;
   }
 
   async getChainID() {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getChainID(new GetChainIDRequest());
     return response.chainId;
   }
 
-  async createAccount(nameOrBech32: string, mnemonic: string, password: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+  async createAccount(
+    nameOrBech32: string,
+    mnemonic: string,
+    password: string,
+  ): Promise<KeyInfo | undefined> {
+    const client = this.#getClient();
     const reponse = await client.createAccount(
       new CreateAccountRequest({
         nameOrBech32,
@@ -149,56 +170,88 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async generateRecoveryPhrase() {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.generateRecoveryPhrase(new GenerateRecoveryPhraseRequest());
     return response.phrase;
   }
 
   async hasKeyByName(name: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByName(new HasKeyByNameRequest({ name }));
     return response.has;
   }
 
   async hasKeyByAddress(address: Uint8Array) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByAddress(new HasKeyByAddressRequest({ address }));
     return response.has;
   }
 
   async hasKeyByNameOrAddress(nameOrBech32: string) {
-    const client = await this.#getClient();
-    const response = await client.hasKeyByNameOrAddress(new HasKeyByNameOrAddressRequest({ nameOrBech32 }));
+    const client = this.#getClient();
+    const response = await client.hasKeyByNameOrAddress(
+      new HasKeyByNameOrAddressRequest({ nameOrBech32 }),
+    );
     return response.has;
   }
 
   async getKeyInfoByName(name: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByName(new GetKeyInfoByNameRequest({ name }));
     return response.key;
   }
 
   async getKeyInfoByAddress(address: Uint8Array): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByAddress(new GetKeyInfoByAddressRequest({ address }));
     return response.key;
   }
 
   async getKeyInfoByNameOrAddress(nameOrBech32: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
-    const response = await client.getKeyInfoByNameOrAddress(new GetKeyInfoByNameOrAddressRequest({ nameOrBech32 }));
+    const client = this.#getClient();
+    const response = await client.getKeyInfoByNameOrAddress(
+      new GetKeyInfoByNameOrAddressRequest({ nameOrBech32 }),
+    );
     return response.key;
   }
 
   async listKeyInfo(): Promise<KeyInfo[]> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.listKeyInfo(new ListKeyInfoRequest());
     return response.keys;
   }
 
+  async makeCallTx(
+    packagePath: string,
+    fnc: string,
+    args: string[],
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress?: Uint8Array,
+    send?: string,
+    memo?: string,
+  ): Promise<MakeTxResponse> {
+    const client = this.#getClient();
+    const reponse = client.makeCallTx({
+      gasFee,
+      gasWanted,
+      memo,
+      callerAddress,
+      msgs: [
+        {
+          packagePath,
+          fnc,
+          args,
+          send,
+        },
+      ],
+    });
+    return reponse;
+  }
+
   async selectAccount(nameOrBech32: string): Promise<SelectAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.selectAccount(
+    const client = this.#getClient();
+    const response = client.selectAccount(
       new SelectAccountRequest({
         nameOrBech32,
       }),
@@ -207,8 +260,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async activateAccount(nameOrBech32: string): Promise<ActivateAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.activateAccount(
+    const client = this.#getClient();
+    const response = client.activateAccount(
       new ActivateAccountRequest({
         nameOrBech32,
       }),
@@ -228,38 +281,45 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async setPassword(password: string, address?: Uint8Array): Promise<SetPasswordResponse> {
-    const client = await this.#getClient();
-    const response = await client.setPassword(new SetPasswordRequest({ password, address }));
+    const client = this.#getClient();
+    const response = client.setPassword(new SetPasswordRequest({ password, address }));
     return response;
   }
 
-  async updatePassword(newPassword: string, address?: Uint8Array): Promise<UpdatePasswordResponse> {
-    const client = await this.#getClient();
-    const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword, address }));
+  async updatePassword(
+    newPassword: string,
+    addresses: Uint8Array[],
+  ): Promise<UpdatePasswordResponse> {
+    const client = this.#getClient();
+    const response = client.updatePassword(new UpdatePasswordRequest({ newPassword, addresses }));
     return response;
   }
 
   async getActiveAccount(): Promise<GetActiveAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.getActiveAccount(new GetActiveAccountRequest());
+    const client = this.#getClient();
+    const response = client.getActiveAccount(new GetActiveAccountRequest());
     return response;
   }
 
   async getActivatedAccount(): Promise<GetActivatedAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.getActivatedAccount(new GetActivatedAccountRequest());
+    const client = this.#getClient();
+    const response = client.getActivatedAccount(new GetActivatedAccountRequest());
     return response;
   }
 
   async queryAccount(address: Uint8Array): Promise<QueryAccountResponse> {
-    const client = await this.#getClient();
-    const reponse = await client.queryAccount(new QueryAccountRequest({ address }));
+    const client = this.#getClient();
+    const reponse = client.queryAccount(new QueryAccountRequest({ address }));
     return reponse;
   }
 
-  async deleteAccount(nameOrBech32: string, password: string | undefined, skipPassword: boolean): Promise<DeleteAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.deleteAccount(
+  async deleteAccount(
+    nameOrBech32: string,
+    password: string | undefined,
+    skipPassword: boolean,
+  ): Promise<DeleteAccountResponse> {
+    const client = this.#getClient();
+    const response = client.deleteAccount(
       new DeleteAccountRequest({
         nameOrBech32,
         password,
@@ -270,8 +330,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async query(path: string, data: Uint8Array): Promise<QueryResponse> {
-    const client = await this.#getClient();
-    const reponse = await client.query(
+    const client = this.#getClient();
+    const reponse = client.query(
       new QueryRequest({
         path,
         data,
@@ -281,7 +341,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async render(packagePath: string, args: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.render(
       new RenderRequest({
         packagePath,
@@ -292,7 +352,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async qEval(packagePath: string, expression: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.qEval(
       new QEvalRequest({
         packagePath,
@@ -307,16 +367,16 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     fnc: string,
     args: string[],
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
   ): Promise<AsyncIterable<CallResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = client.call(
       new CallRequest({
         gasFee,
-        gasWanted: BigInt(gasWanted),
+        gasWanted,
         memo,
         callerAddress,
         msgs: [
@@ -336,15 +396,15 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     toAddress: Uint8Array,
     send: string,
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     memo?: string,
   ): Promise<AsyncIterable<SendResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = client.send(
       new SendRequest({
         gasFee,
-        gasWanted: BigInt(gasWanted),
+        gasWanted,
         memo,
         callerAddress,
         msgs: [
@@ -359,33 +419,41 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async addressToBech32(address: Uint8Array) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressToBech32(new AddressToBech32Request({ address }));
     return response.bech32Address;
   }
 
   async addressFromMnemonic(mnemonic: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressFromMnemonic(new AddressFromMnemonicRequest({ mnemonic }));
     return response.address;
   }
 
   async addressFromBech32(bech32Address: string) {
-    const client = await this.#getClient();
-    const response = await client.addressFromBech32(new AddressFromBech32Request({ bech32Address }));
+    const client = this.#getClient();
+    const response = await client.addressFromBech32(
+      new AddressFromBech32Request({ bech32Address }),
+    );
     return response.address;
+  }
+
+  async broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>> {
+    const client = this.#getClient();
+    const response = client.broadcastTxCommit({ signedTxJson });
+    return response;
   }
 
   // // debug
   async hello(name: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hello(new HelloRequest({ name }));
     return response.greeting;
   }
 
   // // debug
   async helloStream(name: string): Promise<AsyncIterable<HelloStreamResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     return client.helloStream(new HelloRequest({ name }));
   }
 

--- a/examples/js/react-native/hello/api/types.ts
+++ b/examples/js/react-native/hello/api/types.ts
@@ -14,6 +14,9 @@ import {
   SetRemoteResponse,
   UpdatePasswordResponse,
   KeyInfo,
+  SignTxResponse,
+  MakeTxResponse,
+  BroadcastTxCommitResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 
 export enum BridgeStatus {
@@ -50,7 +53,7 @@ export interface GnoKeyApi {
   selectAccount: (nameOrBech32: string) => Promise<SelectAccountResponse>;
   activateAccount: (nameOrBech32: string) => Promise<ActivateAccountResponse>;
   setPassword: (password: string, address?: Uint8Array) => Promise<SetPasswordResponse>;
-  updatePassword: (password: string, address?: Uint8Array) => Promise<UpdatePasswordResponse>;
+  updatePassword: (password: string, addresses: Uint8Array[]) => Promise<UpdatePasswordResponse>;
   getActiveAccount: () => Promise<GetActiveAccountResponse>;
   getActivatedAccount: () => Promise<GetActivatedAccountResponse>;
   queryAccount: (address: Uint8Array) => Promise<QueryAccountResponse>;
@@ -67,7 +70,7 @@ export interface GnoKeyApi {
     fnc: string,
     args: string[],
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
@@ -76,13 +79,30 @@ export interface GnoKeyApi {
     toAddress: Uint8Array,
     send: string,
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     memo?: string,
   ) => Promise<AsyncIterable<SendResponse>>;
   addressToBech32: (address: Uint8Array) => Promise<string>;
   addressFromMnemonic: (mnemonic: string) => Promise<Uint8Array>;
   addressFromBech32: (bech32Address: string) => Promise<Uint8Array>;
+  signTx(
+    txJson: string,
+    address: Uint8Array,
+    accountNumber?: bigint,
+    sequenceNumber?: bigint,
+  ): Promise<SignTxResponse>;
+  makeCallTx(
+    packagePath: string,
+    fnc: string,
+    args: string[],
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress?: Uint8Array,
+    send?: string,
+    memo?: string,
+  ): Promise<MakeTxResponse>;
+  broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>>;
   // debug
   hello: (name: string) => Promise<string>;
   helloStream: (name: string) => Promise<AsyncIterable<HelloStreamResponse>>;

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -133,8 +133,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   async signTx(
     txJson: string,
     address: Uint8Array,
-    accountNumber: bigint,
-    sequenceNumber: bigint,
+    accountNumber: bigint = BigInt(0),
+    sequenceNumber: bigint = BigInt(0),
   ): Promise<SignTxResponse> {
     const client = this.#getClient();
     const response = client.signTx({ txJson, address, accountNumber, sequenceNumber });

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -367,7 +367,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     fnc: string,
     args: string[],
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
@@ -376,7 +376,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     const reponse = client.call(
       new CallRequest({
         gasFee,
-        gasWanted: BigInt(gasWanted),
+        gasWanted,
         memo,
         callerAddress,
         msgs: [
@@ -396,7 +396,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     toAddress: Uint8Array,
     send: string,
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     memo?: string,
   ): Promise<AsyncIterable<SendResponse>> {
@@ -404,7 +404,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     const reponse = client.send(
       new SendRequest({
         gasFee,
-        gasWanted: BigInt(gasWanted),
+        gasWanted,
         memo,
         callerAddress,
         msgs: [

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -438,7 +438,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     return response.address;
   }
 
-  async BroadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>> {
+  async broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>> {
     const client = this.#getClient();
     const response = client.broadcastTxCommit({ signedTxJson });
     return response;

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -2,6 +2,7 @@ import {
   AddressFromBech32Request,
   AddressToBech32Request,
   AddressFromMnemonicRequest,
+  BroadcastTxCommitResponse,
   CallRequest,
   CallResponse,
   CreateAccountRequest,
@@ -24,6 +25,7 @@ import {
   HelloStreamResponse,
   KeyInfo,
   ListKeyInfoRequest,
+  MakeTxResponse,
   MsgCall,
   MsgSend,
   QEvalRequest,
@@ -44,6 +46,7 @@ import {
   SetPasswordResponse,
   SetRemoteRequest,
   SetRemoteResponse,
+  SignTxResponse,
   UpdatePasswordRequest,
   UpdatePasswordResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
@@ -116,25 +119,36 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async setRemote(remote: string): Promise<SetRemoteResponse> {
-    const client = await this.#getClient();
-    const response = await client.setRemote(new SetRemoteRequest({ remote }));
+    const client = this.#getClient();
+    const response = client.setRemote(new SetRemoteRequest({ remote }));
     return response;
   }
 
   async getRemote(): Promise<string> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getRemote(new GetRemoteRequest());
     return response.remote;
   }
 
+  async signTx(
+    txJson: string,
+    address: Uint8Array,
+    accountNumber: bigint,
+    sequenceNumber: bigint,
+  ): Promise<SignTxResponse> {
+    const client = this.#getClient();
+    const response = client.signTx({ txJson, address, accountNumber, sequenceNumber });
+    return response;
+  }
+
   async setChainID(chainId: string): Promise<SetChainIDResponse> {
-    const client = await this.#getClient();
-    const response = await client.setChainID(new SetChainIDRequest({ chainId }));
+    const client = this.#getClient();
+    const response = client.setChainID(new SetChainIDRequest({ chainId }));
     return response;
   }
 
   async getChainID() {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getChainID(new GetChainIDRequest());
     return response.chainId;
   }
@@ -144,7 +158,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     mnemonic: string,
     password: string,
   ): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.createAccount(
       new CreateAccountRequest({
         nameOrBech32,
@@ -156,25 +170,25 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async generateRecoveryPhrase() {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.generateRecoveryPhrase(new GenerateRecoveryPhraseRequest());
     return response.phrase;
   }
 
   async hasKeyByName(name: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByName(new HasKeyByNameRequest({ name }));
     return response.has;
   }
 
   async hasKeyByAddress(address: Uint8Array) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByAddress(new HasKeyByAddressRequest({ address }));
     return response.has;
   }
 
   async hasKeyByNameOrAddress(nameOrBech32: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hasKeyByNameOrAddress(
       new HasKeyByNameOrAddressRequest({ nameOrBech32 }),
     );
@@ -182,19 +196,19 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async getKeyInfoByName(name: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByName(new GetKeyInfoByNameRequest({ name }));
     return response.key;
   }
 
   async getKeyInfoByAddress(address: Uint8Array): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByAddress(new GetKeyInfoByAddressRequest({ address }));
     return response.key;
   }
 
   async getKeyInfoByNameOrAddress(nameOrBech32: string): Promise<KeyInfo | undefined> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.getKeyInfoByNameOrAddress(
       new GetKeyInfoByNameOrAddressRequest({ nameOrBech32 }),
     );
@@ -202,14 +216,42 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async listKeyInfo(): Promise<KeyInfo[]> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.listKeyInfo(new ListKeyInfoRequest());
     return response.keys;
   }
 
+  async makeCallTx(
+    packagePath: string,
+    fnc: string,
+    args: string[],
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress?: Uint8Array,
+    send?: string,
+    memo?: string,
+  ): Promise<MakeTxResponse> {
+    const client = this.#getClient();
+    const reponse = client.makeCallTx({
+      gasFee,
+      gasWanted,
+      memo,
+      callerAddress,
+      msgs: [
+        {
+          packagePath,
+          fnc,
+          args,
+          send,
+        },
+      ],
+    });
+    return reponse;
+  }
+
   async selectAccount(nameOrBech32: string): Promise<SelectAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.selectAccount(
+    const client = this.#getClient();
+    const response = client.selectAccount(
       new SelectAccountRequest({
         nameOrBech32,
       }),
@@ -218,8 +260,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async activateAccount(nameOrBech32: string): Promise<ActivateAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.activateAccount(
+    const client = this.#getClient();
+    const response = client.activateAccount(
       new ActivateAccountRequest({
         nameOrBech32,
       }),
@@ -239,32 +281,35 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async setPassword(password: string, address?: Uint8Array): Promise<SetPasswordResponse> {
-    const client = await this.#getClient();
-    const response = await client.setPassword(new SetPasswordRequest({ password, address }));
+    const client = this.#getClient();
+    const response = client.setPassword(new SetPasswordRequest({ password, address }));
     return response;
   }
 
-  async updatePassword(newPassword: string, addresses: Uint8Array[]): Promise<UpdatePasswordResponse> {
-    const client = await this.#getClient();
-    const response = await client.updatePassword(new UpdatePasswordRequest({ newPassword, addresses }));
+  async updatePassword(
+    newPassword: string,
+    addresses: Uint8Array[],
+  ): Promise<UpdatePasswordResponse> {
+    const client = this.#getClient();
+    const response = client.updatePassword(new UpdatePasswordRequest({ newPassword, addresses }));
     return response;
   }
 
   async getActiveAccount(): Promise<GetActiveAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.getActiveAccount(new GetActiveAccountRequest());
+    const client = this.#getClient();
+    const response = client.getActiveAccount(new GetActiveAccountRequest());
     return response;
   }
 
   async getActivatedAccount(): Promise<GetActivatedAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.getActivatedAccount(new GetActivatedAccountRequest());
+    const client = this.#getClient();
+    const response = client.getActivatedAccount(new GetActivatedAccountRequest());
     return response;
   }
 
   async queryAccount(address: Uint8Array): Promise<QueryAccountResponse> {
-    const client = await this.#getClient();
-    const reponse = await client.queryAccount(new QueryAccountRequest({ address }));
+    const client = this.#getClient();
+    const reponse = client.queryAccount(new QueryAccountRequest({ address }));
     return reponse;
   }
 
@@ -273,8 +318,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     password: string | undefined,
     skipPassword: boolean,
   ): Promise<DeleteAccountResponse> {
-    const client = await this.#getClient();
-    const response = await client.deleteAccount(
+    const client = this.#getClient();
+    const response = client.deleteAccount(
       new DeleteAccountRequest({
         nameOrBech32,
         password,
@@ -285,8 +330,8 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async query(path: string, data: Uint8Array): Promise<QueryResponse> {
-    const client = await this.#getClient();
-    const reponse = await client.query(
+    const client = this.#getClient();
+    const reponse = client.query(
       new QueryRequest({
         path,
         data,
@@ -296,7 +341,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async render(packagePath: string, args: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.render(
       new RenderRequest({
         packagePath,
@@ -307,7 +352,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async qEval(packagePath: string, expression: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = await client.qEval(
       new QEvalRequest({
         packagePath,
@@ -327,7 +372,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     send?: string,
     memo?: string,
   ): Promise<AsyncIterable<CallResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = client.call(
       new CallRequest({
         gasFee,
@@ -355,7 +400,7 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     callerAddress?: Uint8Array,
     memo?: string,
   ): Promise<AsyncIterable<SendResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const reponse = client.send(
       new SendRequest({
         gasFee,
@@ -374,35 +419,41 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
   }
 
   async addressToBech32(address: Uint8Array) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressToBech32(new AddressToBech32Request({ address }));
     return response.bech32Address;
   }
 
   async addressFromMnemonic(mnemonic: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressFromMnemonic(new AddressFromMnemonicRequest({ mnemonic }));
     return response.address;
   }
 
   async addressFromBech32(bech32Address: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.addressFromBech32(
       new AddressFromBech32Request({ bech32Address }),
     );
     return response.address;
   }
 
+  async BroadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>> {
+    const client = this.#getClient();
+    const response = client.broadcastTxCommit({ signedTxJson });
+    return response;
+  }
+
   // // debug
   async hello(name: string) {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     const response = await client.hello(new HelloRequest({ name }));
     return response.greeting;
   }
 
   // // debug
   async helloStream(name: string): Promise<AsyncIterable<HelloStreamResponse>> {
-    const client = await this.#getClient();
+    const client = this.#getClient();
     return client.helloStream(new HelloRequest({ name }));
   }
 

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -14,6 +14,9 @@ import {
   SetRemoteResponse,
   UpdatePasswordResponse,
   KeyInfo,
+  SignTxResponse,
+  MakeTxResponse,
+  BroadcastTxCommitResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 
 export enum BridgeStatus {
@@ -83,6 +86,23 @@ export interface GnoKeyApi {
   addressToBech32: (address: Uint8Array) => Promise<string>;
   addressFromMnemonic: (mnemonic: string) => Promise<Uint8Array>;
   addressFromBech32: (bech32Address: string) => Promise<Uint8Array>;
+  signTx(
+    txJson: string,
+    address: Uint8Array,
+    accountNumber?: bigint,
+    sequenceNumber?: bigint,
+  ): Promise<SignTxResponse>;
+  makeCallTx(
+    packagePath: string,
+    fnc: string,
+    args: string[],
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress?: Uint8Array,
+    send?: string,
+    memo?: string,
+  ): Promise<MakeTxResponse>;
+  broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>>;
   // debug
   hello: (name: string) => Promise<string>;
   helloStream: (name: string) => Promise<AsyncIterable<HelloStreamResponse>>;

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -70,7 +70,7 @@ export interface GnoKeyApi {
     fnc: string,
     args: string[],
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     send?: string,
     memo?: string,
@@ -79,7 +79,7 @@ export interface GnoKeyApi {
     toAddress: Uint8Array,
     send: string,
     gasFee: string,
-    gasWanted: number,
+    gasWanted: bigint,
     callerAddress?: Uint8Array,
     memo?: string,
   ) => Promise<AsyncIterable<SendResponse>>;


### PR DESCRIPTION
This PR adds MakeCallTx, SignTx and BroadcastTxCommit in GnoNativeApi. So the front can directly calls these methods now.
This PR also cleans the GnoNativeApi files, mostly by removing unnecessary `await` keywords.

BREAKING CHANGE: the gasWanted parameter (used in several gRPC message) is now a bigint instead of a number to keep the precision in the calling stack.