### PR TITLE
fix: expo: Update bufbuild and connectrpc dependencies to the latest NPM package

### DIFF
--- a/expo/package-lock.json
+++ b/expo/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "^1.7.2-20240919093120-8280c8c152be.2",
-        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240919093120-8280c8c152be.3",
+        "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20241010133002-359e8f20006f.3",
+        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20241010133002-359e8f20006f.3",
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",
@@ -2464,20 +2464,27 @@
       "peer": true
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.7.2-20240919093120-8280c8c152be.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240919093120-8280c8c152be.2.tgz",
+      "version": "1.8.0-20241010133002-359e8f20006f.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.8.0-20241010133002-359e8f20006f.3.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.7.2"
+        "@bufbuild/protobuf": "^1.8.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es": {
-      "version": "1.4.0-20240919093120-8280c8c152be.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240919093120-8280c8c152be.3.tgz",
+      "version": "1.4.0-20241010133002-359e8f20006f.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20241010133002-359e8f20006f.3.tgz",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240919093120-8280c8c152be.2"
+        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20241010133002-359e8f20006f.2"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/gnolang_gnonative.connectrpc_es/node_modules/@buf/gnolang_gnonative.bufbuild_es": {
+      "version": "1.7.2-20241010133002-359e8f20006f.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20241010133002-359e8f20006f.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.7.2"
       }
     },
     "node_modules/@bufbuild/protobuf": {

--- a/expo/package.json
+++ b/expo/package.json
@@ -29,8 +29,8 @@
   "license": "MIT",
   "homepage": "https://github.com/gnolang/gnonative#readme",
   "dependencies": {
-    "@buf/gnolang_gnonative.bufbuild_es": "^1.7.2-20240919093120-8280c8c152be.2",
-    "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240919093120-8280c8c152be.3",
+    "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20241010133002-359e8f20006f.3",
+    "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20241010133002-359e8f20006f.3",
     "@bufbuild/protobuf": "^1.8.0",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-web": "^1.4.0",


### PR DESCRIPTION
PR https://github.com/gnolang/gnonative/pull/184 did a BREAKING CHANGE to the API and created a new NPM package. Now we need to update expo/package-lock.json to use this for the bufbuild and connectrpc dependencies.

I used `make npm.pack` to create a local package and verified with dSocial builds with it.