### PR TITLE
chore: gnoboard: Use @gnolang/gnonative 3.0.2

### DIFF
--- a/examples/js/expo/gnoboard/package-lock.json
+++ b/examples/js/expo/gnoboard/package-lock.json
@@ -11,7 +11,7 @@
         "@bufbuild/protobuf": "^1.7.2",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",
-        "@gnolang/gnonative": "^3.0.0",
+        "@gnolang/gnonative": "^3.0.2",
         "@react-navigation/bottom-tabs": "^6.5.8",
         "@react-navigation/native": "^6.1.7",
         "@react-navigation/native-stack": "^6.9.13",
@@ -2154,20 +2154,27 @@
       }
     },
     "node_modules/@buf/gnolang_gnonative.bufbuild_es": {
-      "version": "1.7.2-20240919093120-8280c8c152be.2",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20240919093120-8280c8c152be.2.tgz",
+      "version": "1.8.0-20241010133002-359e8f20006f.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.8.0-20241010133002-359e8f20006f.3.tgz",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.7.2"
+        "@bufbuild/protobuf": "^1.8.0"
       }
     },
     "node_modules/@buf/gnolang_gnonative.connectrpc_es": {
-      "version": "1.4.0-20240919093120-8280c8c152be.3",
-      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20240919093120-8280c8c152be.3.tgz",
+      "version": "1.4.0-20241010133002-359e8f20006f.3",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.connectrpc_es/-/gnolang_gnonative.connectrpc_es-1.4.0-20241010133002-359e8f20006f.3.tgz",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20240919093120-8280c8c152be.2"
+        "@buf/gnolang_gnonative.bufbuild_es": "1.7.2-20241010133002-359e8f20006f.2"
       },
       "peerDependencies": {
         "@connectrpc/connect": "^1.4.0"
+      }
+    },
+    "node_modules/@buf/gnolang_gnonative.connectrpc_es/node_modules/@buf/gnolang_gnonative.bufbuild_es": {
+      "version": "1.7.2-20241010133002-359e8f20006f.2",
+      "resolved": "https://buf.build/gen/npm/v1/@buf/gnolang_gnonative.bufbuild_es/-/gnolang_gnonative.bufbuild_es-1.7.2-20241010133002-359e8f20006f.2.tgz",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.7.2"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -3539,13 +3546,13 @@
       }
     },
     "node_modules/@gnolang/gnonative": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-3.0.0.tgz",
-      "integrity": "sha512-2vtfdEp0pCtDdIwupW8KaT948WYFLXT3Re+llEl3XaCmsVTIUKI+/Aicr6u1A5xShbw9FTPsPoBT30hgbk7qaQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@gnolang/gnonative/-/gnonative-3.0.2.tgz",
+      "integrity": "sha512-E4RlPkCpBmVef2UvQWbYhwVw0/N1GyWr3yV23WxXHW3SwqTn+hvuCivIkPwdJyUIRCa/Za1Y5Te5PWqwdvVO7A==",
       "license": "MIT",
       "dependencies": {
-        "@buf/gnolang_gnonative.bufbuild_es": "^1.7.2-20240919093120-8280c8c152be.2",
-        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20240919093120-8280c8c152be.3",
+        "@buf/gnolang_gnonative.bufbuild_es": "^1.8.0-20241010133002-359e8f20006f.3",
+        "@buf/gnolang_gnonative.connectrpc_es": "^1.4.0-20241010133002-359e8f20006f.3",
         "@bufbuild/protobuf": "^1.8.0",
         "@connectrpc/connect": "^1.4.0",
         "@connectrpc/connect-web": "^1.4.0",

--- a/examples/js/expo/gnoboard/package.json
+++ b/examples/js/expo/gnoboard/package.json
@@ -18,7 +18,7 @@
     "@bufbuild/protobuf": "^1.7.2",
     "@connectrpc/connect": "^1.4.0",
     "@connectrpc/connect-web": "^1.4.0",
-    "@gnolang/gnonative": "^3.0.0",
+    "@gnolang/gnonative": "^3.0.2",
     "@react-navigation/bottom-tabs": "^6.5.8",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/native-stack": "^6.9.13",


### PR DESCRIPTION
PR https://github.com/gnolang/gnonative/pull/185 created gnonative NPM package 3.0.2 with the new API that removes deprecated methods. Did `npm install @gnolang/gnonative` to update gnoboard to use it.