### PR TITLE
fix: expo/api: Rename updatePassword to rotatePassword

### DIFF
--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -43,8 +43,8 @@ import {
   SetRemoteRequest,
   SetRemoteResponse,
   SignTxResponse,
-  UpdatePasswordRequest,
-  UpdatePasswordResponse,
+  RotatePasswordRequest,
+  RotatePasswordResponse,
 } from '@buf/gnolang_gnonative.bufbuild_es/gnonativetypes_pb';
 import { GnoNativeService } from '@buf/gnolang_gnonative.connectrpc_es/rpc_connect';
 import { PromiseClient } from '@connectrpc/connect';
@@ -272,12 +272,12 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     return response;
   }
 
-  async updatePassword(
+  async rotatePassword(
     newPassword: string,
     addresses: Uint8Array[],
-  ): Promise<UpdatePasswordResponse> {
+  ): Promise<RotatePasswordResponse> {
     const client = this.#getClient();
-    const response = client.updatePassword(new UpdatePasswordRequest({ newPassword, addresses }));
+    const response = client.rotatePassword(new RotatePasswordRequest({ newPassword, addresses }));
     return response;
   }
 

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -10,7 +10,7 @@ import {
   SetChainIDResponse,
   SetPasswordResponse,
   SetRemoteResponse,
-  UpdatePasswordResponse,
+  RotatePasswordResponse,
   KeyInfo,
   SignTxResponse,
   MakeTxResponse,
@@ -50,7 +50,7 @@ export interface GnoKeyApi {
   getKeyInfoByNameOrAddress: (nameOrBech32: string) => Promise<KeyInfo | undefined>;
   activateAccount: (nameOrBech32: string) => Promise<ActivateAccountResponse>;
   setPassword: (password: string, address: Uint8Array) => Promise<SetPasswordResponse>;
-  updatePassword: (password: string, addresses: Uint8Array[]) => Promise<UpdatePasswordResponse>;
+  rotatePassword: (password: string, addresses: Uint8Array[]) => Promise<RotatePasswordResponse>;
   getActivatedAccount: () => Promise<GetActivatedAccountResponse>;
   queryAccount: (address: Uint8Array) => Promise<QueryAccountResponse>;
   deleteAccount: (


### PR DESCRIPTION
In PR https://github.com/gnolang/gnonative/pull/188, we updated expo dependencies to use the new gnonative package with `RotatePassword`. In the expo TypeScript API, we also need to rename `updatePassword` to `rotatePassword`.