### PR TITLE
fix: gnoNativeService: In RotatePassword, call Lock() after getSigner

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -275,9 +275,6 @@ func (s *gnoNativeService) SetPassword(ctx context.Context, req *connect.Request
 }
 
 func (s *gnoNativeService) RotatePassword(ctx context.Context, req *connect.Request[api_gen.RotatePasswordRequest]) (*connect.Response[api_gen.RotatePasswordResponse], error) {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
 	// Get all the signers, before trying to update the password.
 	var signers = make([]*gnoclient.SignerFromKeybase, len(req.Msg.Addresses))
 	for i := range len(req.Msg.Addresses) {
@@ -287,6 +284,8 @@ func (s *gnoNativeService) RotatePassword(ctx context.Context, req *connect.Requ
 		}
 	}
 
+	s.lock.Lock()
+	defer s.lock.Unlock()
 	getNewPassword := func() (string, error) { return req.Msg.NewPassword, nil }
 	for i := range len(req.Msg.Addresses) {
 		if err := s.keybase.Rotate(signers[i].Account, signers[i].Password, getNewPassword); err != nil {


### PR DESCRIPTION
In gnoNativeService, `RotatePassword` calls `Lock` at the beginning of the function, then [calls `getSigner`](https://github.com/gnolang/gnonative/blob/cdd7bcbfc3b932396e3c469f65859b772d35d44a/service/api.go#L285) . But `getSigner` [calls `RLock`](https://github.com/gnolang/gnonative/blob/cdd7bcbfc3b932396e3c469f65859b772d35d44a/service/service.go#L193) which blocks, and `RotatePassword` never returns. (The effect is that Gnokey Mobile hangs during "Change Master Password".) This PR changes `RotatePassword` to call `Lock` after the loop which calls `getSigner`.

This was tested by doing `make npm.pack` and installing it locally in Gnokey Mobile.