### PR TITLE
chore: Use the latest gnolang/gno. MemPackage is moved to gnovm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	connectrpc.com/connect v1.16.2
 	connectrpc.com/grpchealth v1.3.0
 	connectrpc.com/grpcreflect v1.2.0
-	github.com/gnolang/gno v0.2.1-0.20241016125117-641d2fd91f03
+	github.com/gnolang/gno v0.0.0-20241029141810-12bd8da50dc1
 	github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6
 	github.com/oklog/run v1.1.0
 	github.com/peterbourgon/ff/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gno v0.2.1-0.20241016125117-641d2fd91f03 h1:gyo7GSZ2WzbbGx+KkY8Ldyp5mI8CRVqiLF0RvGJTsSc=
-github.com/gnolang/gno v0.2.1-0.20241016125117-641d2fd91f03/go.mod h1:JcSIol3+SAlhMKHQTjlyoi4CrQqDd/HrrMIsjQpOxxQ=
-github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6 h1:D4dctoTOCk30fbMebwgDYRhcemXrcK7vqjl6MFPUIfc=
-github.com/gnolang/gnokey-mobile v0.0.0-20240903152400-9942eff89ef6/go.mod h1:fD0uCByVS8JKxQbSPOvJxO0s7vdfh1BBXBcv8d+ApDk=
+github.com/gnolang/gno v0.0.0-20241029141810-12bd8da50dc1 h1:MCnDuYOD9MCO5AVN0eHXs9jrLWdHq5P5rYxR1xtQ4XI=
+github.com/gnolang/gno v0.0.0-20241029141810-12bd8da50dc1/go.mod h1:vmnj2WrqRU9/FsHcRSXQdXzQPYYaYns/kYa+x+C0v14=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216 h1:GKvsK3oLWG9B1GL7WP/VqwM6C92j5tIvB844oggL9Lk=
 github.com/gnolang/overflow v0.0.0-20170615021017-4d914c927216/go.mod h1:xJhtEL7ahjM1WJipt89gel8tHzfIl/LyMY+lCYh38d8=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/service/api.go
+++ b/service/api.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/gnolang/gno/gnovm"
 	"github.com/gnolang/gno/tm2/pkg/amino"
 	"github.com/gnolang/gno/tm2/pkg/crypto"
 	"github.com/gnolang/gno/tm2/pkg/crypto/bip39"
@@ -647,8 +648,8 @@ func (s *gnoNativeService) convertRunRequest(req *api_gen.RunRequest) (*gnoclien
 			return nil, nil, getGrpcError(err)
 		}
 
-		memPkg := &std.MemPackage{
-			Files: []*std.MemFile{
+		memPkg := &gnovm.MemPackage{
+			Files: []*gnovm.MemFile{
 				{
 					Name: "main.gno",
 					Body: msg.Package,


### PR DESCRIPTION
PR https://github.com/gnolang/gno/pull/2910 moved `MemPackage` to the gnovm package. We want to track the latest gnolang/gno code. This PR updates to use the latest gnolang/gno and changes the reference of `MemPackage` to gnovm. After we merge this PR, we will update gnokey-mobile to use this latest gnonative, which is possible because gnokey-mobile no longer uses a replace for gnolang/gno.