### PR TITLE
chore: In responses, add Hash and Height

### DIFF
--- a/api/gen/csharp/Gnonativetypes.cs
+++ b/api/gen/csharp/Gnonativetypes.cs
@@ -99,49 +99,53 @@ namespace Land.Gno.Gnonative.V1 {
             "KAlSBmdhc0ZlZRIdCgpnYXNfd2FudGVkGAIgASgSUglnYXNXYW50ZWQSEgoE",
             "bWVtbxgDIAEoCVIEbWVtbxIlCg5jYWxsZXJfYWRkcmVzcxgEIAEoDFINY2Fs",
             "bGVyQWRkcmVzcxIyCgRtc2dzGAUgAygLMh4ubGFuZC5nbm8uZ25vbmF0aXZl",
-            "LnYxLk1zZ0NhbGxSBE1zZ3MiJgoMQ2FsbFJlc3BvbnNlEhYKBnJlc3VsdBgB",
-            "IAEoDFIGcmVzdWx0Il0KB01zZ1NlbmQSHQoKdG9fYWRkcmVzcxgBIAEoDFIJ",
-            "dG9BZGRyZXNzEjMKBmFtb3VudBgCIAMoCzIbLmxhbmQuZ25vLmdub25hdGl2",
-            "ZS52MS5Db2luUgZhbW91bnQitAEKC1NlbmRSZXF1ZXN0EhcKB2dhc19mZWUY",
-            "ASABKAlSBmdhc0ZlZRIdCgpnYXNfd2FudGVkGAIgASgSUglnYXNXYW50ZWQS",
-            "EgoEbWVtbxgDIAEoCVIEbWVtbxIlCg5jYWxsZXJfYWRkcmVzcxgEIAEoDFIN",
-            "Y2FsbGVyQWRkcmVzcxIyCgRtc2dzGAUgAygLMh4ubGFuZC5nbm8uZ25vbmF0",
-            "aXZlLnYxLk1zZ1NlbmRSBE1zZ3MiDgoMU2VuZFJlc3BvbnNlIjYKBk1zZ1J1",
-            "bhIYCgdwYWNrYWdlGAEgASgJUgdwYWNrYWdlEhIKBHNlbmQYAiABKAlSBHNl",
-            "bmQisgEKClJ1blJlcXVlc3QSFwoHZ2FzX2ZlZRgBIAEoCVIGZ2FzRmVlEh0K",
-            "Cmdhc193YW50ZWQYAiABKBJSCWdhc1dhbnRlZBISCgRtZW1vGAMgASgJUgRt",
-            "ZW1vEiUKDmNhbGxlcl9hZGRyZXNzGAQgASgMUg1jYWxsZXJBZGRyZXNzEjEK",
-            "BG1zZ3MYBSADKAsyHS5sYW5kLmduby5nbm9uYXRpdmUudjEuTXNnUnVuUgRN",
-            "c2dzIiUKC1J1blJlc3BvbnNlEhYKBnJlc3VsdBgBIAEoCVIGcmVzdWx0IikK",
-            "Dk1ha2VUeFJlc3BvbnNlEhcKB3R4X2pzb24YASABKAlSBnR4SnNvbiKSAQoN",
-            "U2lnblR4UmVxdWVzdBIXCgd0eF9qc29uGAEgASgJUgZ0eEpzb24SGAoHYWRk",
-            "cmVzcxgCIAEoDFIHYWRkcmVzcxIlCg5hY2NvdW50X251bWJlchgDIAEoBFIN",
-            "YWNjb3VudE51bWJlchInCg9zZXF1ZW5jZV9udW1iZXIYBCABKARSDnNlcXVl",
-            "bmNlTnVtYmVyIjEKDlNpZ25UeFJlc3BvbnNlEh8KDnNpZ25lZF90eF9qc29u",
-            "GAEgASgJUgd0eF9qc29uIt0BChJFc3RpbWF0ZUdhc1JlcXVlc3QSFwoHdHhf",
-            "anNvbhgBIAEoCVIGdHhKc29uEhgKB2FkZHJlc3MYAiABKAxSB2FkZHJlc3MS",
-            "JwoPc2VjdXJpdHlfbWFyZ2luGAMgASgNUg5zZWN1cml0eU1hcmdpbhIbCgl1",
-            "cGRhdGVfdHgYBCABKAhSCHVwZGF0ZVR4EiUKDmFjY291bnRfbnVtYmVyGAUg",
-            "ASgEUg1hY2NvdW50TnVtYmVyEicKD3NlcXVlbmNlX251bWJlchgGIAEoBFIO",
-            "c2VxdWVuY2VOdW1iZXIiTQoTRXN0aW1hdGVHYXNSZXNwb25zZRIXCgd0eF9q",
-            "c29uGAEgASgJUgZ0eEpzb24SHQoKZ2FzX3dhbnRlZBgCIAEoElIJZ2FzV2Fu",
-            "dGVkIjsKGEJyb2FkY2FzdFR4Q29tbWl0UmVxdWVzdBIfCg5zaWduZWRfdHhf",
-            "anNvbhgBIAEoCVIHdHhfanNvbiIzChlCcm9hZGNhc3RUeENvbW1pdFJlc3Bv",
-            "bnNlEhYKBnJlc3VsdBgBIAEoDFIGcmVzdWx0IjIKFkFkZHJlc3NUb0JlY2gz",
-            "MlJlcXVlc3QSGAoHYWRkcmVzcxgBIAEoDFIHYWRkcmVzcyJAChdBZGRyZXNz",
-            "VG9CZWNoMzJSZXNwb25zZRIlCg5iZWNoMzJfYWRkcmVzcxgBIAEoCVINYmVj",
-            "aDMyQWRkcmVzcyJBChhBZGRyZXNzRnJvbUJlY2gzMlJlcXVlc3QSJQoOYmVj",
-            "aDMyX2FkZHJlc3MYASABKAlSDWJlY2gzMkFkZHJlc3MiNQoZQWRkcmVzc0Zy",
-            "b21CZWNoMzJSZXNwb25zZRIYCgdhZGRyZXNzGAEgASgMUgdhZGRyZXNzIjgK",
-            "GkFkZHJlc3NGcm9tTW5lbW9uaWNSZXF1ZXN0EhoKCG1uZW1vbmljGAEgASgJ",
-            "UghtbmVtb25pYyI3ChtBZGRyZXNzRnJvbU1uZW1vbmljUmVzcG9uc2USGAoH",
-            "YWRkcmVzcxgBIAEoDFIHYWRkcmVzcyIiCgxIZWxsb1JlcXVlc3QSEgoEbmFt",
-            "ZRgBIAEoCVIETmFtZSIrCg1IZWxsb1Jlc3BvbnNlEhoKCGdyZWV0aW5nGAEg",
-            "ASgJUghHcmVldGluZyIoChJIZWxsb1N0cmVhbVJlcXVlc3QSEgoEbmFtZRgB",
-            "IAEoCVIETmFtZSIxChNIZWxsb1N0cmVhbVJlc3BvbnNlEhoKCGdyZWV0aW5n",
-            "GAEgASgJUghHcmVldGluZyIwChhHTk9OQVRJVkVUWVBFU19CeXRlc0xpc3QS",
-            "FAoFVmFsdWUYASADKAxSBVZhbHVlQilaJ2dpdGh1Yi5jb20vZ25vbGFuZy9n",
-            "bm9uYXRpdmUvYXBpL2dlbi9nb2IGcHJvdG8z"));
+            "LnYxLk1zZ0NhbGxSBE1zZ3MiUgoMQ2FsbFJlc3BvbnNlEhYKBnJlc3VsdBgB",
+            "IAEoDFIGcmVzdWx0EhIKBGhhc2gYAiABKAxSBGhhc2gSFgoGaGVpZ2h0GAMg",
+            "ASgSUgZoZWlnaHQiXQoHTXNnU2VuZBIdCgp0b19hZGRyZXNzGAEgASgMUgl0",
+            "b0FkZHJlc3MSMwoGYW1vdW50GAIgAygLMhsubGFuZC5nbm8uZ25vbmF0aXZl",
+            "LnYxLkNvaW5SBmFtb3VudCK0AQoLU2VuZFJlcXVlc3QSFwoHZ2FzX2ZlZRgB",
+            "IAEoCVIGZ2FzRmVlEh0KCmdhc193YW50ZWQYAiABKBJSCWdhc1dhbnRlZBIS",
+            "CgRtZW1vGAMgASgJUgRtZW1vEiUKDmNhbGxlcl9hZGRyZXNzGAQgASgMUg1j",
+            "YWxsZXJBZGRyZXNzEjIKBG1zZ3MYBSADKAsyHi5sYW5kLmduby5nbm9uYXRp",
+            "dmUudjEuTXNnU2VuZFIETXNncyI6CgxTZW5kUmVzcG9uc2USEgoEaGFzaBgB",
+            "IAEoDFIEaGFzaBIWCgZoZWlnaHQYAiABKBJSBmhlaWdodCI2CgZNc2dSdW4S",
+            "GAoHcGFja2FnZRgBIAEoCVIHcGFja2FnZRISCgRzZW5kGAIgASgJUgRzZW5k",
+            "IrIBCgpSdW5SZXF1ZXN0EhcKB2dhc19mZWUYASABKAlSBmdhc0ZlZRIdCgpn",
+            "YXNfd2FudGVkGAIgASgSUglnYXNXYW50ZWQSEgoEbWVtbxgDIAEoCVIEbWVt",
+            "bxIlCg5jYWxsZXJfYWRkcmVzcxgEIAEoDFINY2FsbGVyQWRkcmVzcxIxCgRt",
+            "c2dzGAUgAygLMh0ubGFuZC5nbm8uZ25vbmF0aXZlLnYxLk1zZ1J1blIETXNn",
+            "cyJRCgtSdW5SZXNwb25zZRIWCgZyZXN1bHQYASABKAlSBnJlc3VsdBISCgRo",
+            "YXNoGAIgASgMUgRoYXNoEhYKBmhlaWdodBgDIAEoElIGaGVpZ2h0IikKDk1h",
+            "a2VUeFJlc3BvbnNlEhcKB3R4X2pzb24YASABKAlSBnR4SnNvbiKSAQoNU2ln",
+            "blR4UmVxdWVzdBIXCgd0eF9qc29uGAEgASgJUgZ0eEpzb24SGAoHYWRkcmVz",
+            "cxgCIAEoDFIHYWRkcmVzcxIlCg5hY2NvdW50X251bWJlchgDIAEoBFINYWNj",
+            "b3VudE51bWJlchInCg9zZXF1ZW5jZV9udW1iZXIYBCABKARSDnNlcXVlbmNl",
+            "TnVtYmVyIjEKDlNpZ25UeFJlc3BvbnNlEh8KDnNpZ25lZF90eF9qc29uGAEg",
+            "ASgJUgd0eF9qc29uIt0BChJFc3RpbWF0ZUdhc1JlcXVlc3QSFwoHdHhfanNv",
+            "bhgBIAEoCVIGdHhKc29uEhgKB2FkZHJlc3MYAiABKAxSB2FkZHJlc3MSJwoP",
+            "c2VjdXJpdHlfbWFyZ2luGAMgASgNUg5zZWN1cml0eU1hcmdpbhIbCgl1cGRh",
+            "dGVfdHgYBCABKAhSCHVwZGF0ZVR4EiUKDmFjY291bnRfbnVtYmVyGAUgASgE",
+            "Ug1hY2NvdW50TnVtYmVyEicKD3NlcXVlbmNlX251bWJlchgGIAEoBFIOc2Vx",
+            "dWVuY2VOdW1iZXIiTQoTRXN0aW1hdGVHYXNSZXNwb25zZRIXCgd0eF9qc29u",
+            "GAEgASgJUgZ0eEpzb24SHQoKZ2FzX3dhbnRlZBgCIAEoElIJZ2FzV2FudGVk",
+            "IjsKGEJyb2FkY2FzdFR4Q29tbWl0UmVxdWVzdBIfCg5zaWduZWRfdHhfanNv",
+            "bhgBIAEoCVIHdHhfanNvbiJfChlCcm9hZGNhc3RUeENvbW1pdFJlc3BvbnNl",
+            "EhYKBnJlc3VsdBgBIAEoDFIGcmVzdWx0EhIKBGhhc2gYAiABKAxSBGhhc2gS",
+            "FgoGaGVpZ2h0GAMgASgSUgZoZWlnaHQiMgoWQWRkcmVzc1RvQmVjaDMyUmVx",
+            "dWVzdBIYCgdhZGRyZXNzGAEgASgMUgdhZGRyZXNzIkAKF0FkZHJlc3NUb0Jl",
+            "Y2gzMlJlc3BvbnNlEiUKDmJlY2gzMl9hZGRyZXNzGAEgASgJUg1iZWNoMzJB",
+            "ZGRyZXNzIkEKGEFkZHJlc3NGcm9tQmVjaDMyUmVxdWVzdBIlCg5iZWNoMzJf",
+            "YWRkcmVzcxgBIAEoCVINYmVjaDMyQWRkcmVzcyI1ChlBZGRyZXNzRnJvbUJl",
+            "Y2gzMlJlc3BvbnNlEhgKB2FkZHJlc3MYASABKAxSB2FkZHJlc3MiOAoaQWRk",
+            "cmVzc0Zyb21NbmVtb25pY1JlcXVlc3QSGgoIbW5lbW9uaWMYASABKAlSCG1u",
+            "ZW1vbmljIjcKG0FkZHJlc3NGcm9tTW5lbW9uaWNSZXNwb25zZRIYCgdhZGRy",
+            "ZXNzGAEgASgMUgdhZGRyZXNzIiIKDEhlbGxvUmVxdWVzdBISCgRuYW1lGAEg",
+            "ASgJUgROYW1lIisKDUhlbGxvUmVzcG9uc2USGgoIZ3JlZXRpbmcYASABKAlS",
+            "CEdyZWV0aW5nIigKEkhlbGxvU3RyZWFtUmVxdWVzdBISCgRuYW1lGAEgASgJ",
+            "UgROYW1lIjEKE0hlbGxvU3RyZWFtUmVzcG9uc2USGgoIZ3JlZXRpbmcYASAB",
+            "KAlSCEdyZWV0aW5nIjAKGEdOT05BVElWRVRZUEVTX0J5dGVzTGlzdBIUCgVW",
+            "YWx1ZRgBIAMoDFIFVmFsdWVCKVonZ2l0aHViLmNvbS9nbm9sYW5nL2dub25h",
+            "dGl2ZS9hcGkvZ2VuL2dvYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(null, null, new pbr::GeneratedClrTypeInfo[] {
@@ -194,20 +198,20 @@ namespace Land.Gno.Gnonative.V1 {
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.QEvalResponse), global::Land.Gno.Gnonative.V1.QEvalResponse.Parser, new[]{ "Result" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.MsgCall), global::Land.Gno.Gnonative.V1.MsgCall.Parser, new[]{ "PackagePath", "Fnc", "Args", "Send" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.CallRequest), global::Land.Gno.Gnonative.V1.CallRequest.Parser, new[]{ "GasFee", "GasWanted", "Memo", "CallerAddress", "Msgs" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.CallResponse), global::Land.Gno.Gnonative.V1.CallResponse.Parser, new[]{ "Result" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.CallResponse), global::Land.Gno.Gnonative.V1.CallResponse.Parser, new[]{ "Result", "Hash", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.MsgSend), global::Land.Gno.Gnonative.V1.MsgSend.Parser, new[]{ "ToAddress", "Amount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.SendRequest), global::Land.Gno.Gnonative.V1.SendRequest.Parser, new[]{ "GasFee", "GasWanted", "Memo", "CallerAddress", "Msgs" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.SendResponse), global::Land.Gno.Gnonative.V1.SendResponse.Parser, null, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.SendResponse), global::Land.Gno.Gnonative.V1.SendResponse.Parser, new[]{ "Hash", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.MsgRun), global::Land.Gno.Gnonative.V1.MsgRun.Parser, new[]{ "Package", "Send" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.RunRequest), global::Land.Gno.Gnonative.V1.RunRequest.Parser, new[]{ "GasFee", "GasWanted", "Memo", "CallerAddress", "Msgs" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.RunResponse), global::Land.Gno.Gnonative.V1.RunResponse.Parser, new[]{ "Result" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.RunResponse), global::Land.Gno.Gnonative.V1.RunResponse.Parser, new[]{ "Result", "Hash", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.MakeTxResponse), global::Land.Gno.Gnonative.V1.MakeTxResponse.Parser, new[]{ "TxJson" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.SignTxRequest), global::Land.Gno.Gnonative.V1.SignTxRequest.Parser, new[]{ "TxJson", "Address", "AccountNumber", "SequenceNumber" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.SignTxResponse), global::Land.Gno.Gnonative.V1.SignTxResponse.Parser, new[]{ "SignedTxJson" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.EstimateGasRequest), global::Land.Gno.Gnonative.V1.EstimateGasRequest.Parser, new[]{ "TxJson", "Address", "SecurityMargin", "UpdateTx", "AccountNumber", "SequenceNumber" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.EstimateGasResponse), global::Land.Gno.Gnonative.V1.EstimateGasResponse.Parser, new[]{ "TxJson", "GasWanted" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.BroadcastTxCommitRequest), global::Land.Gno.Gnonative.V1.BroadcastTxCommitRequest.Parser, new[]{ "SignedTxJson" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.BroadcastTxCommitResponse), global::Land.Gno.Gnonative.V1.BroadcastTxCommitResponse.Parser, new[]{ "Result" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.BroadcastTxCommitResponse), global::Land.Gno.Gnonative.V1.BroadcastTxCommitResponse.Parser, new[]{ "Result", "Hash", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.AddressToBech32Request), global::Land.Gno.Gnonative.V1.AddressToBech32Request.Parser, new[]{ "Address" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.AddressToBech32Response), global::Land.Gno.Gnonative.V1.AddressToBech32Response.Parser, new[]{ "Bech32Address" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::Land.Gno.Gnonative.V1.AddressFromBech32Request), global::Land.Gno.Gnonative.V1.AddressFromBech32Request.Parser, new[]{ "Bech32Address" }, null, null, null, null),
@@ -10765,6 +10769,8 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public CallResponse(CallResponse other) : this() {
       result_ = other.result_;
+      hash_ = other.hash_;
+      height_ = other.height_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -10786,6 +10792,36 @@ namespace Land.Gno.Gnonative.V1 {
       }
     }
 
+    /// <summary>Field number for the "hash" field.</summary>
+    public const int HashFieldNumber = 2;
+    private pb::ByteString hash_ = pb::ByteString.Empty;
+    /// <summary>
+    /// The transaction hash
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString Hash {
+      get { return hash_; }
+      set {
+        hash_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "height" field.</summary>
+    public const int HeightFieldNumber = 3;
+    private long height_;
+    /// <summary>
+    /// The transaction height
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public long Height {
+      get { return height_; }
+      set {
+        height_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -10802,6 +10838,8 @@ namespace Land.Gno.Gnonative.V1 {
         return true;
       }
       if (Result != other.Result) return false;
+      if (Hash != other.Hash) return false;
+      if (Height != other.Height) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -10810,6 +10848,8 @@ namespace Land.Gno.Gnonative.V1 {
     public override int GetHashCode() {
       int hash = 1;
       if (Result.Length != 0) hash ^= Result.GetHashCode();
+      if (Hash.Length != 0) hash ^= Hash.GetHashCode();
+      if (Height != 0L) hash ^= Height.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -10832,6 +10872,14 @@ namespace Land.Gno.Gnonative.V1 {
         output.WriteRawTag(10);
         output.WriteBytes(Result);
       }
+      if (Hash.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(24);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -10846,6 +10894,14 @@ namespace Land.Gno.Gnonative.V1 {
         output.WriteRawTag(10);
         output.WriteBytes(Result);
       }
+      if (Hash.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(24);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -10858,6 +10914,12 @@ namespace Land.Gno.Gnonative.V1 {
       int size = 0;
       if (Result.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(Result);
+      }
+      if (Hash.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(Hash);
+      }
+      if (Height != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt64Size(Height);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -10873,6 +10935,12 @@ namespace Land.Gno.Gnonative.V1 {
       }
       if (other.Result.Length != 0) {
         Result = other.Result;
+      }
+      if (other.Hash.Length != 0) {
+        Hash = other.Hash;
+      }
+      if (other.Height != 0L) {
+        Height = other.Height;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -10897,6 +10965,14 @@ namespace Land.Gno.Gnonative.V1 {
             Result = input.ReadBytes();
             break;
           }
+          case 18: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 24: {
+            Height = input.ReadSInt64();
+            break;
+          }
         }
       }
     #endif
@@ -10918,6 +10994,14 @@ namespace Land.Gno.Gnonative.V1 {
             break;
           case 10: {
             Result = input.ReadBytes();
+            break;
+          }
+          case 18: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 24: {
+            Height = input.ReadSInt64();
             break;
           }
         }
@@ -11537,6 +11621,8 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public SendResponse(SendResponse other) : this() {
+      hash_ = other.hash_;
+      height_ = other.height_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -11544,6 +11630,36 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public SendResponse Clone() {
       return new SendResponse(this);
+    }
+
+    /// <summary>Field number for the "hash" field.</summary>
+    public const int HashFieldNumber = 1;
+    private pb::ByteString hash_ = pb::ByteString.Empty;
+    /// <summary>
+    /// The transaction hash
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString Hash {
+      get { return hash_; }
+      set {
+        hash_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "height" field.</summary>
+    public const int HeightFieldNumber = 2;
+    private long height_;
+    /// <summary>
+    /// The transaction height
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public long Height {
+      get { return height_; }
+      set {
+        height_ = value;
+      }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11561,6 +11677,8 @@ namespace Land.Gno.Gnonative.V1 {
       if (ReferenceEquals(other, this)) {
         return true;
       }
+      if (Hash != other.Hash) return false;
+      if (Height != other.Height) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -11568,6 +11686,8 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override int GetHashCode() {
       int hash = 1;
+      if (Hash.Length != 0) hash ^= Hash.GetHashCode();
+      if (Height != 0L) hash ^= Height.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -11586,6 +11706,14 @@ namespace Land.Gno.Gnonative.V1 {
     #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       output.WriteRawMessage(this);
     #else
+      if (Hash.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(16);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -11596,6 +11724,14 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Hash.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(16);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -11606,6 +11742,12 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public int CalculateSize() {
       int size = 0;
+      if (Hash.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(Hash);
+      }
+      if (Height != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt64Size(Height);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -11617,6 +11759,12 @@ namespace Land.Gno.Gnonative.V1 {
     public void MergeFrom(SendResponse other) {
       if (other == null) {
         return;
+      }
+      if (other.Hash.Length != 0) {
+        Hash = other.Hash;
+      }
+      if (other.Height != 0L) {
+        Height = other.Height;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -11637,6 +11785,14 @@ namespace Land.Gno.Gnonative.V1 {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
             break;
+          case 10: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 16: {
+            Height = input.ReadSInt64();
+            break;
+          }
         }
       }
     #endif
@@ -11656,6 +11812,14 @@ namespace Land.Gno.Gnonative.V1 {
           default:
             _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
             break;
+          case 10: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 16: {
+            Height = input.ReadSInt64();
+            break;
+          }
         }
       }
     }
@@ -12285,6 +12449,8 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public RunResponse(RunResponse other) : this() {
       result_ = other.result_;
+      hash_ = other.hash_;
+      height_ = other.height_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -12309,6 +12475,36 @@ namespace Land.Gno.Gnonative.V1 {
       }
     }
 
+    /// <summary>Field number for the "hash" field.</summary>
+    public const int HashFieldNumber = 2;
+    private pb::ByteString hash_ = pb::ByteString.Empty;
+    /// <summary>
+    /// The transaction hash
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString Hash {
+      get { return hash_; }
+      set {
+        hash_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "height" field.</summary>
+    public const int HeightFieldNumber = 3;
+    private long height_;
+    /// <summary>
+    /// The transaction height
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public long Height {
+      get { return height_; }
+      set {
+        height_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -12325,6 +12521,8 @@ namespace Land.Gno.Gnonative.V1 {
         return true;
       }
       if (Result != other.Result) return false;
+      if (Hash != other.Hash) return false;
+      if (Height != other.Height) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -12333,6 +12531,8 @@ namespace Land.Gno.Gnonative.V1 {
     public override int GetHashCode() {
       int hash = 1;
       if (Result.Length != 0) hash ^= Result.GetHashCode();
+      if (Hash.Length != 0) hash ^= Hash.GetHashCode();
+      if (Height != 0L) hash ^= Height.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -12355,6 +12555,14 @@ namespace Land.Gno.Gnonative.V1 {
         output.WriteRawTag(10);
         output.WriteString(Result);
       }
+      if (Hash.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(24);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -12369,6 +12577,14 @@ namespace Land.Gno.Gnonative.V1 {
         output.WriteRawTag(10);
         output.WriteString(Result);
       }
+      if (Hash.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(24);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -12381,6 +12597,12 @@ namespace Land.Gno.Gnonative.V1 {
       int size = 0;
       if (Result.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Result);
+      }
+      if (Hash.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(Hash);
+      }
+      if (Height != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt64Size(Height);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -12396,6 +12618,12 @@ namespace Land.Gno.Gnonative.V1 {
       }
       if (other.Result.Length != 0) {
         Result = other.Result;
+      }
+      if (other.Hash.Length != 0) {
+        Hash = other.Hash;
+      }
+      if (other.Height != 0L) {
+        Height = other.Height;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -12420,6 +12648,14 @@ namespace Land.Gno.Gnonative.V1 {
             Result = input.ReadString();
             break;
           }
+          case 18: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 24: {
+            Height = input.ReadSInt64();
+            break;
+          }
         }
       }
     #endif
@@ -12441,6 +12677,14 @@ namespace Land.Gno.Gnonative.V1 {
             break;
           case 10: {
             Result = input.ReadString();
+            break;
+          }
+          case 18: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 24: {
+            Height = input.ReadSInt64();
             break;
           }
         }
@@ -13258,7 +13502,7 @@ namespace Land.Gno.Gnonative.V1 {
     private uint securityMargin_;
     /// <summary>
     /// The security margin to apply to the estimated gas amount.
-    /// This number is represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
+    /// This number represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
     /// It will be multiplied by the estimated gas amount.
     /// </summary>
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14054,6 +14298,8 @@ namespace Land.Gno.Gnonative.V1 {
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public BroadcastTxCommitResponse(BroadcastTxCommitResponse other) : this() {
       result_ = other.result_;
+      hash_ = other.hash_;
+      height_ = other.height_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -14075,6 +14321,36 @@ namespace Land.Gno.Gnonative.V1 {
       }
     }
 
+    /// <summary>Field number for the "hash" field.</summary>
+    public const int HashFieldNumber = 2;
+    private pb::ByteString hash_ = pb::ByteString.Empty;
+    /// <summary>
+    /// The transaction hash
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public pb::ByteString Hash {
+      get { return hash_; }
+      set {
+        hash_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "height" field.</summary>
+    public const int HeightFieldNumber = 3;
+    private long height_;
+    /// <summary>
+    /// The transaction height
+    /// </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public long Height {
+      get { return height_; }
+      set {
+        height_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -14091,6 +14367,8 @@ namespace Land.Gno.Gnonative.V1 {
         return true;
       }
       if (Result != other.Result) return false;
+      if (Hash != other.Hash) return false;
+      if (Height != other.Height) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -14099,6 +14377,8 @@ namespace Land.Gno.Gnonative.V1 {
     public override int GetHashCode() {
       int hash = 1;
       if (Result.Length != 0) hash ^= Result.GetHashCode();
+      if (Hash.Length != 0) hash ^= Hash.GetHashCode();
+      if (Height != 0L) hash ^= Height.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -14121,6 +14401,14 @@ namespace Land.Gno.Gnonative.V1 {
         output.WriteRawTag(10);
         output.WriteBytes(Result);
       }
+      if (Hash.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(24);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -14135,6 +14423,14 @@ namespace Land.Gno.Gnonative.V1 {
         output.WriteRawTag(10);
         output.WriteBytes(Result);
       }
+      if (Hash.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteBytes(Hash);
+      }
+      if (Height != 0L) {
+        output.WriteRawTag(24);
+        output.WriteSInt64(Height);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -14147,6 +14443,12 @@ namespace Land.Gno.Gnonative.V1 {
       int size = 0;
       if (Result.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeBytesSize(Result);
+      }
+      if (Hash.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeBytesSize(Hash);
+      }
+      if (Height != 0L) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt64Size(Height);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -14162,6 +14464,12 @@ namespace Land.Gno.Gnonative.V1 {
       }
       if (other.Result.Length != 0) {
         Result = other.Result;
+      }
+      if (other.Hash.Length != 0) {
+        Hash = other.Hash;
+      }
+      if (other.Height != 0L) {
+        Height = other.Height;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -14186,6 +14494,14 @@ namespace Land.Gno.Gnonative.V1 {
             Result = input.ReadBytes();
             break;
           }
+          case 18: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 24: {
+            Height = input.ReadSInt64();
+            break;
+          }
         }
       }
     #endif
@@ -14207,6 +14523,14 @@ namespace Land.Gno.Gnonative.V1 {
             break;
           case 10: {
             Result = input.ReadBytes();
+            break;
+          }
+          case 18: {
+            Hash = input.ReadBytes();
+            break;
+          }
+          case 24: {
+            Height = input.ReadSInt64();
             break;
           }
         }

--- a/api/gen/csharp/RpcGrpc.cs
+++ b/api/gen/csharp/RpcGrpc.cs
@@ -870,7 +870,7 @@ namespace Land.Gno.Gnonative.V1 {
       }
 
       /// <summary>
-      /// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+      /// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
       /// If UpdateTx is true, then update the transaction with the gasWanted amount.
       /// </summary>
       /// <param name="request">The request received from the client.</param>
@@ -2452,7 +2452,7 @@ namespace Land.Gno.Gnonative.V1 {
         return CallInvoker.AsyncUnaryCall(__Method_MakeRunTx, null, options, request);
       }
       /// <summary>
-      /// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+      /// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
       /// If UpdateTx is true, then update the transaction with the gasWanted amount.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
@@ -2466,7 +2466,7 @@ namespace Land.Gno.Gnonative.V1 {
         return EstimateGas(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+      /// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
       /// If UpdateTx is true, then update the transaction with the gasWanted amount.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
@@ -2478,7 +2478,7 @@ namespace Land.Gno.Gnonative.V1 {
         return CallInvoker.BlockingUnaryCall(__Method_EstimateGas, null, options, request);
       }
       /// <summary>
-      /// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+      /// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
       /// If UpdateTx is true, then update the transaction with the gasWanted amount.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>
@@ -2492,7 +2492,7 @@ namespace Land.Gno.Gnonative.V1 {
         return EstimateGasAsync(request, new grpc::CallOptions(headers, deadline, cancellationToken));
       }
       /// <summary>
-      /// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+      /// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
       /// If UpdateTx is true, then update the transaction with the gasWanted amount.
       /// </summary>
       /// <param name="request">The request to send to the server.</param>

--- a/api/gen/es/gnonativetypes_pb.ts
+++ b/api/gen/es/gnonativetypes_pb.ts
@@ -1992,6 +1992,20 @@ export class CallResponse extends Message<CallResponse> {
    */
   result = new Uint8Array(0);
 
+  /**
+   * The transaction hash
+   *
+   * @generated from field: bytes hash = 2;
+   */
+  hash = new Uint8Array(0);
+
+  /**
+   * The transaction height
+   *
+   * @generated from field: sint64 height = 3;
+   */
+  height = protoInt64.zero;
+
   constructor(data?: PartialMessage<CallResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2001,6 +2015,8 @@ export class CallResponse extends Message<CallResponse> {
   static readonly typeName = "land.gno.gnonative.v1.CallResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "result", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 2, name: "hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "height", kind: "scalar", T: 18 /* ScalarType.SINT64 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CallResponse {
@@ -2139,6 +2155,20 @@ export class SendRequest extends Message<SendRequest> {
  * @generated from message land.gno.gnonative.v1.SendResponse
  */
 export class SendResponse extends Message<SendResponse> {
+  /**
+   * The transaction hash
+   *
+   * @generated from field: bytes hash = 1;
+   */
+  hash = new Uint8Array(0);
+
+  /**
+   * The transaction height
+   *
+   * @generated from field: sint64 height = 2;
+   */
+  height = protoInt64.zero;
+
   constructor(data?: PartialMessage<SendResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2147,6 +2177,8 @@ export class SendResponse extends Message<SendResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "land.gno.gnonative.v1.SendResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 2, name: "height", kind: "scalar", T: 18 /* ScalarType.SINT64 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SendResponse {
@@ -2292,6 +2324,20 @@ export class RunResponse extends Message<RunResponse> {
    */
   result = "";
 
+  /**
+   * The transaction hash
+   *
+   * @generated from field: bytes hash = 2;
+   */
+  hash = new Uint8Array(0);
+
+  /**
+   * The transaction height
+   *
+   * @generated from field: sint64 height = 3;
+   */
+  height = protoInt64.zero;
+
   constructor(data?: PartialMessage<RunResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2301,6 +2347,8 @@ export class RunResponse extends Message<RunResponse> {
   static readonly typeName = "land.gno.gnonative.v1.RunResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "result", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "height", kind: "scalar", T: 18 /* ScalarType.SINT64 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RunResponse {
@@ -2481,7 +2529,7 @@ export class EstimateGasRequest extends Message<EstimateGasRequest> {
 
   /**
    * The security margin to apply to the estimated gas amount.
-   * This number is represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
+   * This number represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
    * It will be multiplied by the estimated gas amount.
    *
    * @generated from field: uint32 security_margin = 3;
@@ -2637,6 +2685,20 @@ export class BroadcastTxCommitResponse extends Message<BroadcastTxCommitResponse
    */
   result = new Uint8Array(0);
 
+  /**
+   * The transaction hash
+   *
+   * @generated from field: bytes hash = 2;
+   */
+  hash = new Uint8Array(0);
+
+  /**
+   * The transaction height
+   *
+   * @generated from field: sint64 height = 3;
+   */
+  height = protoInt64.zero;
+
   constructor(data?: PartialMessage<BroadcastTxCommitResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2646,6 +2708,8 @@ export class BroadcastTxCommitResponse extends Message<BroadcastTxCommitResponse
   static readonly typeName = "land.gno.gnonative.v1.BroadcastTxCommitResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "result", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 2, name: "hash", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 3, name: "height", kind: "scalar", T: 18 /* ScalarType.SINT64 */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BroadcastTxCommitResponse {

--- a/api/gen/es/rpc_connect.ts
+++ b/api/gen/es/rpc_connect.ts
@@ -372,7 +372,7 @@ export const GnoNativeService = {
       kind: MethodKind.Unary,
     },
     /**
-     * EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+     * EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
      * If UpdateTx is true, then update the transaction with the gasWanted amount.
      *
      * @generated from rpc land.gno.gnonative.v1.GnoNativeService.EstimateGas

--- a/api/gen/go/_goconnect/rpc.connect.go
+++ b/api/gen/go/_goconnect/rpc.connect.go
@@ -242,7 +242,7 @@ type GnoNativeServiceClient interface {
 	MakeSendTx(context.Context, *connect.Request[_go.SendRequest]) (*connect.Response[_go.MakeTxResponse], error)
 	// Make an unsigned transaction to temporarily load the code in package on the blockchain and run main().
 	MakeRunTx(context.Context, *connect.Request[_go.RunRequest]) (*connect.Response[_go.MakeTxResponse], error)
-	// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+	// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
 	// If UpdateTx is true, then update the transaction with the gasWanted amount.
 	EstimateGas(context.Context, *connect.Request[_go.EstimateGasRequest]) (*connect.Response[_go.EstimateGasResponse], error)
 	// Sign the transaction using the account with the given address.
@@ -821,7 +821,7 @@ type GnoNativeServiceHandler interface {
 	MakeSendTx(context.Context, *connect.Request[_go.SendRequest]) (*connect.Response[_go.MakeTxResponse], error)
 	// Make an unsigned transaction to temporarily load the code in package on the blockchain and run main().
 	MakeRunTx(context.Context, *connect.Request[_go.RunRequest]) (*connect.Response[_go.MakeTxResponse], error)
-	// EstimateGas estimate the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
+	// EstimateGas estimates the least amount of gas required for the transaction to go through on the chain (minimum gas wanted), with a security margin.
 	// If UpdateTx is true, then update the transaction with the gasWanted amount.
 	EstimateGas(context.Context, *connect.Request[_go.EstimateGasRequest]) (*connect.Response[_go.EstimateGasResponse], error)
 	// Sign the transaction using the account with the given address.

--- a/api/gen/go/gnonativetypes.pb.go
+++ b/api/gen/go/gnonativetypes.pb.go
@@ -2361,8 +2361,12 @@ func (x *CallRequest) GetMsgs() []*MsgCall {
 }
 
 type CallResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Result        []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Result []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	// The transaction hash
+	Hash []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
+	// The transaction height
+	Height        int64 `protobuf:"zigzag64,3,opt,name=height,proto3" json:"height,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2402,6 +2406,20 @@ func (x *CallResponse) GetResult() []byte {
 		return x.Result
 	}
 	return nil
+}
+
+func (x *CallResponse) GetHash() []byte {
+	if x != nil {
+		return x.Hash
+	}
+	return nil
+}
+
+func (x *CallResponse) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
 }
 
 type MsgSend struct {
@@ -2539,7 +2557,11 @@ func (x *SendRequest) GetMsgs() []*MsgSend {
 }
 
 type SendResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The transaction hash
+	Hash []byte `protobuf:"bytes,1,opt,name=hash,proto3" json:"hash,omitempty"`
+	// The transaction height
+	Height        int64 `protobuf:"zigzag64,2,opt,name=height,proto3" json:"height,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2572,6 +2594,20 @@ func (x *SendResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use SendResponse.ProtoReflect.Descriptor instead.
 func (*SendResponse) Descriptor() ([]byte, []int) {
 	return file_gnonativetypes_proto_rawDescGZIP(), []int{52}
+}
+
+func (x *SendResponse) GetHash() []byte {
+	if x != nil {
+		return x.Hash
+	}
+	return nil
+}
+
+func (x *SendResponse) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
 }
 
 type MsgRun struct {
@@ -2711,7 +2747,11 @@ func (x *RunRequest) GetMsgs() []*MsgRun {
 type RunResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The "console" output from the run
-	Result        string `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	Result string `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	// The transaction hash
+	Hash []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
+	// The transaction height
+	Height        int64 `protobuf:"zigzag64,3,opt,name=height,proto3" json:"height,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2751,6 +2791,20 @@ func (x *RunResponse) GetResult() string {
 		return x.Result
 	}
 	return ""
+}
+
+func (x *RunResponse) GetHash() []byte {
+	if x != nil {
+		return x.Hash
+	}
+	return nil
+}
+
+func (x *RunResponse) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
 }
 
 type MakeTxResponse struct {
@@ -2922,7 +2976,7 @@ type EstimateGasRequest struct {
 	// The address of the account to sign the transaction
 	Address []byte `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
 	// The security margin to apply to the estimated gas amount.
-	// This number is represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
+	// This number represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
 	// It will be multiplied by the estimated gas amount.
 	SecurityMargin uint32 `protobuf:"varint,3,opt,name=security_margin,json=securityMargin,proto3" json:"security_margin,omitempty"`
 	// The update boolean to update the gas wanted field in the transaction if true.
@@ -3107,8 +3161,12 @@ func (x *BroadcastTxCommitRequest) GetSignedTxJson() string {
 }
 
 type BroadcastTxCommitResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Result        []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	state  protoimpl.MessageState `protogen:"open.v1"`
+	Result []byte                 `protobuf:"bytes,1,opt,name=result,proto3" json:"result,omitempty"`
+	// The transaction hash
+	Hash []byte `protobuf:"bytes,2,opt,name=hash,proto3" json:"hash,omitempty"`
+	// The transaction height
+	Height        int64 `protobuf:"zigzag64,3,opt,name=height,proto3" json:"height,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3148,6 +3206,20 @@ func (x *BroadcastTxCommitResponse) GetResult() []byte {
 		return x.Result
 	}
 	return nil
+}
+
+func (x *BroadcastTxCommitResponse) GetHash() []byte {
+	if x != nil {
+		return x.Hash
+	}
+	return nil
+}
+
+func (x *BroadcastTxCommitResponse) GetHeight() int64 {
+	if x != nil {
+		return x.Height
+	}
+	return 0
 }
 
 type AddressToBech32Request struct {
@@ -3759,9 +3831,11 @@ const file_gnonativetypes_proto_rawDesc = "" +
 	"gas_wanted\x18\x02 \x01(\x12R\tgasWanted\x12\x12\n" +
 	"\x04memo\x18\x03 \x01(\tR\x04memo\x12%\n" +
 	"\x0ecaller_address\x18\x04 \x01(\fR\rcallerAddress\x122\n" +
-	"\x04msgs\x18\x05 \x03(\v2\x1e.land.gno.gnonative.v1.MsgCallR\x04Msgs\"&\n" +
+	"\x04msgs\x18\x05 \x03(\v2\x1e.land.gno.gnonative.v1.MsgCallR\x04Msgs\"R\n" +
 	"\fCallResponse\x12\x16\n" +
-	"\x06result\x18\x01 \x01(\fR\x06result\"]\n" +
+	"\x06result\x18\x01 \x01(\fR\x06result\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\fR\x04hash\x12\x16\n" +
+	"\x06height\x18\x03 \x01(\x12R\x06height\"]\n" +
 	"\aMsgSend\x12\x1d\n" +
 	"\n" +
 	"to_address\x18\x01 \x01(\fR\ttoAddress\x123\n" +
@@ -3772,8 +3846,10 @@ const file_gnonativetypes_proto_rawDesc = "" +
 	"gas_wanted\x18\x02 \x01(\x12R\tgasWanted\x12\x12\n" +
 	"\x04memo\x18\x03 \x01(\tR\x04memo\x12%\n" +
 	"\x0ecaller_address\x18\x04 \x01(\fR\rcallerAddress\x122\n" +
-	"\x04msgs\x18\x05 \x03(\v2\x1e.land.gno.gnonative.v1.MsgSendR\x04Msgs\"\x0e\n" +
-	"\fSendResponse\"6\n" +
+	"\x04msgs\x18\x05 \x03(\v2\x1e.land.gno.gnonative.v1.MsgSendR\x04Msgs\":\n" +
+	"\fSendResponse\x12\x12\n" +
+	"\x04hash\x18\x01 \x01(\fR\x04hash\x12\x16\n" +
+	"\x06height\x18\x02 \x01(\x12R\x06height\"6\n" +
 	"\x06MsgRun\x12\x18\n" +
 	"\apackage\x18\x01 \x01(\tR\apackage\x12\x12\n" +
 	"\x04send\x18\x02 \x01(\tR\x04send\"\xb2\x01\n" +
@@ -3784,9 +3860,11 @@ const file_gnonativetypes_proto_rawDesc = "" +
 	"gas_wanted\x18\x02 \x01(\x12R\tgasWanted\x12\x12\n" +
 	"\x04memo\x18\x03 \x01(\tR\x04memo\x12%\n" +
 	"\x0ecaller_address\x18\x04 \x01(\fR\rcallerAddress\x121\n" +
-	"\x04msgs\x18\x05 \x03(\v2\x1d.land.gno.gnonative.v1.MsgRunR\x04Msgs\"%\n" +
+	"\x04msgs\x18\x05 \x03(\v2\x1d.land.gno.gnonative.v1.MsgRunR\x04Msgs\"Q\n" +
 	"\vRunResponse\x12\x16\n" +
-	"\x06result\x18\x01 \x01(\tR\x06result\")\n" +
+	"\x06result\x18\x01 \x01(\tR\x06result\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\fR\x04hash\x12\x16\n" +
+	"\x06height\x18\x03 \x01(\x12R\x06height\")\n" +
 	"\x0eMakeTxResponse\x12\x17\n" +
 	"\atx_json\x18\x01 \x01(\tR\x06txJson\"\x92\x01\n" +
 	"\rSignTxRequest\x12\x17\n" +
@@ -3808,9 +3886,11 @@ const file_gnonativetypes_proto_rawDesc = "" +
 	"\n" +
 	"gas_wanted\x18\x02 \x01(\x12R\tgasWanted\";\n" +
 	"\x18BroadcastTxCommitRequest\x12\x1f\n" +
-	"\x0esigned_tx_json\x18\x01 \x01(\tR\atx_json\"3\n" +
+	"\x0esigned_tx_json\x18\x01 \x01(\tR\atx_json\"_\n" +
 	"\x19BroadcastTxCommitResponse\x12\x16\n" +
-	"\x06result\x18\x01 \x01(\fR\x06result\"2\n" +
+	"\x06result\x18\x01 \x01(\fR\x06result\x12\x12\n" +
+	"\x04hash\x18\x02 \x01(\fR\x04hash\x12\x16\n" +
+	"\x06height\x18\x03 \x01(\x12R\x06height\"2\n" +
 	"\x16AddressToBech32Request\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\fR\aaddress\"@\n" +
 	"\x17AddressToBech32Response\x12%\n" +

--- a/api/gnonativetypes.proto
+++ b/api/gnonativetypes.proto
@@ -244,6 +244,10 @@ message CallRequest {
 
 message CallResponse {
 	bytes result = 1;
+	// The transaction hash
+	bytes hash = 2;
+	// The transaction height
+	sint64 height = 3;
 }
 
 message MsgSend {
@@ -266,6 +270,10 @@ message SendRequest {
 }
 
 message SendResponse {
+	// The transaction hash
+	bytes hash = 1;
+	// The transaction height
+	sint64 height = 2;
 }
 
 message MsgRun {
@@ -290,6 +298,10 @@ message RunRequest {
 message RunResponse {
 	// The "console" output from the run
 	string result = 1;
+	// The transaction hash
+	bytes hash = 2;
+	// The transaction height
+	sint64 height = 3;
 }
 
 message MakeTxResponse {
@@ -319,7 +331,7 @@ message EstimateGasRequest {
 	// The address of the account to sign the transaction
 	bytes address = 2;
 	// The security margin to apply to the estimated gas amount.
-	// This number is represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
+	// This number represents a decimal numeral value with two decimals precision, without the decimal separator. E.g. 1 means 0.01 and 10000 means 100.00.
 	// It will be multiplied by the estimated gas amount.
 	uint32 security_margin = 3;
 	// The update boolean to update the gas wanted field in the transaction if true.
@@ -344,6 +356,10 @@ message BroadcastTxCommitRequest {
 
 message BroadcastTxCommitResponse {
 	bytes result = 1;
+	// The transaction hash
+	bytes hash = 2;
+	// The transaction height
+	sint64 height = 3;
 }
 
 message AddressToBech32Request {

--- a/api/gnonativetypes/gnonativetypes.go
+++ b/api/gnonativetypes/gnonativetypes.go
@@ -231,6 +231,10 @@ type CallRequest struct {
 
 type CallResponse struct {
 	Result []byte `json:"result" yaml:"result"`
+	// The transaction hash
+	Hash []byte `json:"hash" yaml:"hash"`
+	// The transaction height
+	Height int64 `json:"height" yaml:"height"`
 }
 
 type MsgSend struct {
@@ -252,7 +256,12 @@ type SendRequest struct {
 	Msgs []MsgSend
 }
 
-type SendResponse struct{}
+type SendResponse struct {
+	// The transaction hash
+	Hash []byte `json:"hash" yaml:"hash"`
+	// The transaction height
+	Height int64 `json:"height" yaml:"height"`
+}
 
 type MsgRun struct {
 	// The code for the script package. Must have main().
@@ -276,6 +285,10 @@ type RunRequest struct {
 type RunResponse struct {
 	// The "console" output from the run
 	Result string `json:"result" yaml:"result"`
+	// The transaction hash
+	Hash []byte `json:"hash" yaml:"hash"`
+	// The transaction height
+	Height int64 `json:"height" yaml:"height"`
 }
 
 type MakeTxResponse struct {
@@ -330,6 +343,10 @@ type BroadcastTxCommitRequest struct {
 
 type BroadcastTxCommitResponse struct {
 	Result []byte `json:"result" yaml:"result"`
+	// The transaction hash
+	Hash []byte `json:"hash" yaml:"hash"`
+	// The transaction height
+	Height int64 `json:"height" yaml:"height"`
 }
 
 type AddressToBech32Request struct {

--- a/gen.sum
+++ b/gen.sum
@@ -1,6 +1,6 @@
 db011306fec5f34668398da58861399025f4abc8  Makefile
-7a387d7bfb5d14219f29c20f514ba776614ce115  api/gnonativetypes.proto
-b3a62b4554dce917cce1508d128ce8eb13728362  api/gnonativetypes/gnonativetypes.go
+0e412091f1a154757feab346c180d7d66bbb21c9  api/gnonativetypes.proto
+d04862a1dae9e71b4ed147a99127e7285eadb718  api/gnonativetypes/gnonativetypes.go
 c68dfdb1ce5523ded45cf1ea8b047c818fa287b2  api/gnonativetypes/package.go
-5121c32fa3005f1c424cea70c1d527cfa906fec2  api/rpc.proto
+4c8d735f44576d927eed99a8ef941ff1c05d9b8b  api/rpc.proto
 82528f7a615e9c3f322667fcc4e1100a00b1a708  buf.gen.yaml

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/sig-0/insertion-queue v0.0.0-20241004125609-6b3ca841346b // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gno v0.0.0-20250114141614-d54d00470dd1 h1:+alAep+xeCs0eZ0gX9w49SzMrJLNn6kCn/GdigL5/gE=
-github.com/gnolang/gno v0.0.0-20250114141614-d54d00470dd1/go.mod h1:rrkFgXBwKCYw/Rt62+RUVAXe6cG7TPYHiX87ocMnTdI=
 github.com/gnolang/gno v0.0.0-20250331145021-c48fc5a8e8ef h1:s03lVK0RiVdcko0PV14eGEl9Mpz7s+plj7tFUyAe82k=
 github.com/gnolang/gno v0.0.0-20250331145021-c48fc5a8e8ef/go.mod h1:uMBHj+WwBv4kU7WZZ6M6jMXTzjDU4yBSCVSL3zWOuGA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -161,6 +159,8 @@ github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
 github.com/tailscale/depaware v0.0.0-20210622194025-720c4b409502/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zondax/hid v0.9.2 h1:WCJFnEDMiqGF64nlZz28E9qLVZ0KSJ7xpc5DLEyma2U=

--- a/service/api.go
+++ b/service/api.go
@@ -432,6 +432,8 @@ func (s *gnoNativeService) Call(ctx context.Context, req *connect.Request[api_ge
 
 	if err := stream.Send(&api_gen.CallResponse{
 		Result: bres.DeliverTx.Data,
+		Hash:   bres.Hash,
+		Height: bres.Height,
 	}); err != nil {
 		s.logger.Error("Call stream.Send returned error", zap.Error(err))
 		return err
@@ -489,12 +491,15 @@ func (s *gnoNativeService) Send(ctx context.Context, req *connect.Request[api_ge
 	if err != nil {
 		return getGrpcError(err)
 	}
-	_, err = c.Send(*cfg, msgs...)
+	bres, err := c.Send(*cfg, msgs...)
 	if err != nil {
 		return getGrpcError(err)
 	}
 
-	if err := stream.Send(&api_gen.SendResponse{}); err != nil {
+	if err := stream.Send(&api_gen.SendResponse{
+		Hash:   bres.Hash,
+		Height: bres.Height,
+	}); err != nil {
 		s.logger.Error("Send stream.Send returned error", zap.Error(err))
 		return err
 	}
@@ -549,6 +554,8 @@ func (s *gnoNativeService) Run(ctx context.Context, req *connect.Request[api_gen
 
 	if err := stream.Send(&api_gen.RunResponse{
 		Result: string(bres.DeliverTx.Data),
+		Hash:   bres.Hash,
+		Height: bres.Height,
 	}); err != nil {
 		s.logger.Error("Run stream.Send returned error", zap.Error(err))
 		return err
@@ -732,6 +739,8 @@ func (s *gnoNativeService) BroadcastTxCommit(ctx context.Context, req *connect.R
 
 	if err := stream.Send(&api_gen.BroadcastTxCommitResponse{
 		Result: bres.DeliverTx.Data,
+		Hash:   bres.Hash,
+		Height: bres.Height,
 	}); err != nil {
 		s.logger.Error("BroadcastTxCommit stream.Send returned error", zap.Error(err))
 		return err


### PR DESCRIPTION
In goclient, the `ResultBroadcastTxCommit` contains the [transaction hash and height](https://github.com/gnolang/gno/blob/84abee0162e9253ef3bfa475f5b4b1fc5ef4f8c3/tm2/pkg/bft/rpc/core/types/responses.go#L160-L161). In Gno Key Mobile, we have a use case for showing the transaction hash. So update the gRPC types `CallResponse`, etc. to include the hash and height.
* In `gnonativetypes`, add `Hash` and `Height` to responses where possible
* Run `make regenerate`
* In the `gnoNativeService` API, put the `Hash` and `Height` in the response

Here is test code for [dSocial `broadcastTxCommit`](https://github.com/gnoverse/dsocial/blob/b25344b553bf350812052a9efe98f1db6e276848/mobile/redux/features/linkingSlice.ts#L99) .
```
    for await (const res of await gnonative.broadcastTxCommit(signedTx)) {
        console.log("broadcasted tx: ", res);
        console.log("broadcasted TX HASH: ", Buffer.from(res.hash).toString('base64'));
    }
```
It prints `broadcasted TX HASH:  djAPQOCWlCPeGC6j+pAuCzYw32dyiQCmJ/7uwf/d6r4=`