### PR TITLE
chore: goclient: Change to an active example page

### DIFF
--- a/examples/go/goclient/main.go
+++ b/examples/go/goclient/main.go
@@ -134,8 +134,8 @@ func exampleAction(client _goconnect.GnoNativeServiceClient) error {
 	res, err := client.Render(
 		context.Background(),
 		connect.NewRequest(&api_gen.RenderRequest{
-			PackagePath: "gno.land/r/demo/boards",
-			Args:        "gnonative/1",
+			PackagePath: "gno.land/r/gnoland/pages",
+			Args:        "p/partners",
 		}),
 	)
 	if err != nil {


### PR DESCRIPTION
The goclient example call the Render function to show an example page. In the past, the default gnoland node had posts in the r/demo/boards realm. But it doesn't anymore. Change to r/gnoland/pages which does have content.

`go run . uds` shows:
```
2025/05/15 13:36:37 <main class='gno-tmpl-page'>

# Partnerships

### Fund and Grants Program

Are you a builder, tinkerer, or researcher? If you’re looking to create awesome dApps, tooling, infrastructure,
or smart contract libraries on gno.land, you can apply for a grant. The gno.land Ecosystem Fund and Grants program
provides financial contributions for individuals and teams to innovate on the platform.

...
```