### PR TITLE
fix: convertRunRequest: std.MemPackage needs a Name

### DIFF
--- a/service/api.go
+++ b/service/api.go
@@ -580,6 +580,8 @@ func (s *gnoNativeService) convertRunRequest(req *api_gen.RunRequest) (*gnoclien
 		}
 
 		memPkg := &std.MemPackage{
+			Name: "main",
+			// Path will be automatically set by handler.
 			Files: []*std.MemFile{
 				{
 					Name: "main.gno",


### PR DESCRIPTION
After the recent "crossing" changes, `TestRunSingle_Integration`, etc. were updated so that `std.MemPackage` [needs a `Name`](https://github.com/gnolang/gno/blob/9b763e9b11a55be644f33208840ad2e8f88336af/gno.land/pkg/gnoclient/integration_test.go#L340-L341) so that the back end handler can use it to set the `Path`. We need to do the same. Without this, calling `Run` results in an "invalid path" error.