### PR TITLE
feat: Bring expo up to date with gRPC API

### DIFF
--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -14,6 +14,7 @@ import {
   QueryResponse,
   ActivateAccountResponse,
   SendResponse,
+  RunResponse,
   SetChainIDResponse,
   SetPasswordResponse,
   SetRemoteResponse,
@@ -149,6 +150,20 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     return reponse.key;
   }
 
+  async createLedger(
+    name: string,
+    algorithm: string,
+    hrp: string,
+  ): Promise<KeyInfo | undefined> {
+    const client = this.#getClient();
+    const reponse = await client.createLedger({
+      name,
+      algorithm,
+      hrp,
+    });
+    return reponse.key;
+  }
+
   async generateRecoveryPhrase() {
     const client = this.#getClient();
     const response = await client.generateRecoveryPhrase({});
@@ -245,6 +260,32 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
         {
           toAddress,
           amount,
+        },
+      ],
+    });
+    return reponse;
+  }
+
+  async makeRunTx(
+    pkg: string,
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress: Uint8Array,
+    send?: Coin[],
+    maxDeposit?: Coin[],
+    memo?: string,
+  ): Promise<MakeTxResponse> {
+    const client = this.#getClient();
+    const reponse = client.makeRunTx({
+      gasFee,
+      gasWanted,
+      memo,
+      callerAddress,
+      msgs: [
+        {
+          package: pkg,
+          send,
+          maxDeposit,
         },
       ],
     });
@@ -371,6 +412,32 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
         {
           toAddress,
           amount,
+        },
+      ],
+    });
+    return reponse;
+  }
+
+  async run(
+    pkg: string,
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress: Uint8Array,
+    send?: Coin[],
+    maxDeposit?: Coin[],
+    memo?: string,
+  ): Promise<AsyncIterable<RunResponse>> {
+    const client = this.#getClient();
+    const reponse = client.run({
+      gasFee,
+      gasWanted,
+      callerAddress,
+      memo,
+      msgs: [
+        {
+          package: pkg,
+          send,
+          maxDeposit,
         },
       ],
     });

--- a/expo/src/api/GnoNativeApi.ts
+++ b/expo/src/api/GnoNativeApi.ts
@@ -140,12 +140,18 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     nameOrBech32: string,
     mnemonic: string,
     password: string,
+    bip39Passwd?: string,
+    account?: number,
+    index?: number,
   ): Promise<KeyInfo | undefined> {
     const client = this.#getClient();
     const reponse = await client.createAccount({
       nameOrBech32,
       mnemonic,
       password,
+      bip39Passwd,
+      account,
+      index,
     });
     return reponse.key;
   }
@@ -154,12 +160,16 @@ export class GnoNativeApi implements GnoKeyApi, GoBridgeInterface {
     name: string,
     algorithm: string,
     hrp: string,
+    account?: number,
+    index?: number,
   ): Promise<KeyInfo | undefined> {
     const client = this.#getClient();
     const reponse = await client.createLedger({
       name,
       algorithm,
       hrp,
+      account,
+      index,
     });
     return reponse.key;
   }

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -40,11 +40,16 @@ export interface GnoKeyApi {
     nameOrBech32: string,
     mnemonic: string,
     password: string,
+    bip39Passwd?: string,
+    account?: number,
+    index?: number,
   ) => Promise<KeyInfo | undefined>;
   createLedger: (
     name: string,
     algorithm: string,
     hrp: string,
+    account?: number,
+    index?: number,
   ) => Promise<KeyInfo | undefined>;
   generateRecoveryPhrase: () => Promise<string>;
   listKeyInfo: () => Promise<KeyInfo[]>;

--- a/expo/src/api/types.ts
+++ b/expo/src/api/types.ts
@@ -7,6 +7,7 @@ import {
   QueryResponse,
   ActivateAccountResponse,
   SendResponse,
+  RunResponse,
   SetChainIDResponse,
   SetPasswordResponse,
   SetRemoteResponse,
@@ -39,6 +40,11 @@ export interface GnoKeyApi {
     nameOrBech32: string,
     mnemonic: string,
     password: string,
+  ) => Promise<KeyInfo | undefined>;
+  createLedger: (
+    name: string,
+    algorithm: string,
+    hrp: string,
   ) => Promise<KeyInfo | undefined>;
   generateRecoveryPhrase: () => Promise<string>;
   listKeyInfo: () => Promise<KeyInfo[]>;
@@ -80,6 +86,15 @@ export interface GnoKeyApi {
     callerAddress: Uint8Array,
     memo?: string,
   ) => Promise<AsyncIterable<SendResponse>>;
+  run: (
+    pkg: string,
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress: Uint8Array,
+    send?: Coin[],
+    maxDeposit?: Coin[],
+    memo?: string,
+  ) => Promise<AsyncIterable<RunResponse>>;
   addressToBech32: (address: Uint8Array) => Promise<string>;
   addressFromMnemonic: (mnemonic: string) => Promise<Uint8Array>;
   addressFromBech32: (bech32Address: string) => Promise<Uint8Array>;
@@ -118,6 +133,15 @@ export interface GnoKeyApi {
     callerAddress: Uint8Array,
     memo?: string,
   ): Promise<MakeTxResponse>;
+  makeRunTx: (
+    pkg: string,
+    gasFee: string,
+    gasWanted: bigint,
+    callerAddress: Uint8Array,
+    send?: Coin[],
+    maxDeposit?: Coin[],
+    memo?: string,
+  ) => Promise<MakeTxResponse>;
   broadcastTxCommit(signedTxJson: string): Promise<AsyncIterable<BroadcastTxCommitResponse>>;
   // debug
   hello: (name: string) => Promise<string>;


### PR DESCRIPTION
In expo/src/api types.ts and GnoNativeApi.ts, add functions and optional params to bring expo up to date with the gRPC API:
* Add `run`, `makeRunTx` and `createLedger`
* In `createAccount`, add optional params `bip39Passwd`, `account` and `index` from [the gRPC API](https://github.com/gnolang/gnonative/blob/28ad53a4ef5bb5bb99b9eed29d72de59f256456b/api/gnonativetypes/gnonativetypes.go#L130-L133)

This PR only adds new functions and optional params. It should not break any existing code.