### PR TITLE
feat: Use the latest gnolang/gno, compatible with fixed gnodev

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	connectrpc.com/connect v1.16.2
 	connectrpc.com/grpchealth v1.3.0
 	connectrpc.com/grpcreflect v1.2.0
-	github.com/gnolang/gno v0.0.0-20250716085632-95d5f5e743c9
+	github.com/gnolang/gno v0.0.0-20250728014947-2e6b56fe460e
 	github.com/oklog/run v1.1.0
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/peterbourgon/unixtransport v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/gnolang/gno v0.0.0-20250716085632-95d5f5e743c9 h1:l7ZQlINkpbXUQmsJHpkpgXzZDcDgGFinYyMotJtyAoE=
-github.com/gnolang/gno v0.0.0-20250716085632-95d5f5e743c9/go.mod h1:oN4YCrDStwh0ujnzTRygplKJOonnWDbyleYT+1Za+aU=
+github.com/gnolang/gno v0.0.0-20250728014947-2e6b56fe460e h1:bE4o4vRmlkXHMK52LiNPR1IaTzql1IO6AyRezqQSTFQ=
+github.com/gnolang/gno v0.0.0-20250728014947-2e6b56fe460e/go.mod h1:oN4YCrDStwh0ujnzTRygplKJOonnWDbyleYT+1Za+aU=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
PR https://github.com/gnolang/gno/pull/4564 fixes the "100% CPU" problem with gnodev. We want to use this, so we update go.mod to the latest gnolang/gno.

I confirmed that `make regenerate` doesn't change any gRPC files.
I confirmed that `make npm.pack` in the expo folder can build.