### PR TITLE
fix: remote npm token and use IODC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
   semantic-release:
     runs-on: macos-latest
     timeout-minutes: 20
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,4 +78,4 @@ jobs:
           working_directory: ./expo
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Migrate from old npm tokens to trusted publishers: https://docs.npmjs.com/trusted-publishers