### PR TITLE
fix: npm trusted publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: write
+      issues: write
+      pull-requests: write
       id-token: write
     steps:
       - name: Checkout
@@ -73,9 +75,8 @@ jobs:
         run: npm install
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         with:
           working_directory: ./expo
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Updates the semantic-release action to v6 so npm publishing can use OIDC trusted publishing without NPM_TOKEN.

Also adds the GitHub permissions required by @semantic-release/github and removes the explicit provenance env var since npm trusted publishing handles provenance automatically.