### PR TITLE
fix: reduce npm package size

### DIFF
--- a/expo/.npmignore
+++ b/expo/.npmignore
@@ -10,3 +10,4 @@ __tests__
 /android/build/
 /example/
 /ios/Frameworks/GnoCore.xcframework/ios-arm64_x86_64-simulator/GnoCore.framework/Versions
+/ios/Frameworks/GnoCore.xcframework/ios-arm64/GnoCore.framework/Versions


### PR DESCRIPTION
## Summary
- exclude duplicate iOS device framework Versions directory from npm package
- keep package size below npm publish payload limit

## Verification
- rebuilt package size: 142490151 bytes (~142.5 MB), down from failed CI package at 202.7 MB

Compiled and tested with gnokey-mobile on Android and iOS.